### PR TITLE
[Pipeline] Create CRUD API Endpoints for Snippets

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,86 @@
 import express from 'express';
 import path from 'path';
+import { SnippetStore } from './store/snippet-store';
 
 const app = express();
+export const snippetStore = new SnippetStore();
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..', 'public')));
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+// POST /api/snippets — create snippet
+app.post('/api/snippets', (req, res) => {
+  const { title, code, language, description, tags } = req.body as Record<string, unknown>;
+  if (!title || !code) {
+    res.status(400).json({ error: 'title and code are required' });
+    return;
+  }
+  const snippet = snippetStore.create({
+    title: title as string,
+    code: code as string,
+    language: (language as string) ?? '',
+    description: (description as string) ?? undefined,
+    tags: (tags as string[]) ?? undefined,
+  });
+  res.status(201).json(snippet);
+});
+
+// GET /api/snippets — list all, supports ?language=X and ?tag=X
+app.get('/api/snippets', (req, res) => {
+  const { language, tag } = req.query as Record<string, string | undefined>;
+  let snippets = snippetStore.getAll();
+  if (language) snippets = snippetStore.filterByLanguage(language);
+  if (tag) snippets = snippetStore.filterByTag(tag);
+  res.json({ snippets, count: snippets.length });
+});
+
+// GET /api/snippets/search?q=term — full-text search
+app.get('/api/snippets/search', (req, res) => {
+  const { q } = req.query as { q?: string };
+  if (!q) {
+    res.status(400).json({ error: 'q query parameter is required' });
+    return;
+  }
+  const snippets = snippetStore.searchByText(q);
+  res.json({ snippets, count: snippets.length });
+});
+
+// GET /api/snippets/:id — get one
+app.get('/api/snippets/:id', (req, res) => {
+  const snippet = snippetStore.getById(req.params.id);
+  if (!snippet) {
+    res.status(404).json({ error: 'Snippet not found' });
+    return;
+  }
+  res.json(snippet);
+});
+
+// PUT /api/snippets/:id — update
+app.put('/api/snippets/:id', (req, res) => {
+  if (!req.body || Object.keys(req.body as object).length === 0) {
+    res.status(400).json({ error: 'Request body must not be empty' });
+    return;
+  }
+  const snippet = snippetStore.update(req.params.id, req.body as Record<string, unknown>);
+  if (!snippet) {
+    res.status(404).json({ error: 'Snippet not found' });
+    return;
+  }
+  res.json(snippet);
+});
+
+// DELETE /api/snippets/:id — delete
+app.delete('/api/snippets/:id', (req, res) => {
+  const deleted = snippetStore.delete(req.params.id);
+  if (!deleted) {
+    res.status(404).json({ error: 'Snippet not found' });
+    return;
+  }
+  res.status(204).send();
 });
 
 export default app;

--- a/src/tests/snippets-api.test.ts
+++ b/src/tests/snippets-api.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app, { snippetStore } from '../app';
+
+describe('Snippets CRUD API', () => {
+  beforeEach(() => {
+    // Clear store between tests by replacing internal map
+    (snippetStore as unknown as { store: Map<string, unknown> }).store.clear();
+  });
+
+  describe('POST /api/snippets', () => {
+    it('creates a snippet and returns 201', async () => {
+      const res = await request(app).post('/api/snippets').send({
+        title: 'My Snippet',
+        code: 'console.log("hi")',
+        language: 'typescript',
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeTruthy();
+      expect(res.body.title).toBe('My Snippet');
+    });
+
+    it('returns 400 if title missing', async () => {
+      const res = await request(app).post('/api/snippets').send({ code: 'x', language: 'js' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeTruthy();
+    });
+
+    it('returns 400 if code missing', async () => {
+      const res = await request(app).post('/api/snippets').send({ title: 'T', language: 'js' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeTruthy();
+    });
+  });
+
+  describe('GET /api/snippets', () => {
+    it('returns all snippets', async () => {
+      await request(app).post('/api/snippets').send({ title: 'A', code: 'a', language: 'js' });
+      await request(app).post('/api/snippets').send({ title: 'B', code: 'b', language: 'ts' });
+      const res = await request(app).get('/api/snippets');
+      expect(res.status).toBe(200);
+      expect(res.body.snippets).toHaveLength(2);
+      expect(res.body.count).toBe(2);
+    });
+
+    it('filters by language', async () => {
+      await request(app).post('/api/snippets').send({ title: 'A', code: 'a', language: 'javascript' });
+      await request(app).post('/api/snippets').send({ title: 'B', code: 'b', language: 'python' });
+      const res = await request(app).get('/api/snippets?language=javascript');
+      expect(res.status).toBe(200);
+      expect(res.body.snippets).toHaveLength(1);
+      expect(res.body.snippets[0].language).toBe('javascript');
+    });
+
+    it('filters by tag', async () => {
+      await request(app).post('/api/snippets').send({ title: 'A', code: 'a', language: 'js', tags: ['react'] });
+      await request(app).post('/api/snippets').send({ title: 'B', code: 'b', language: 'js', tags: ['vue'] });
+      const res = await request(app).get('/api/snippets?tag=react');
+      expect(res.status).toBe(200);
+      expect(res.body.snippets).toHaveLength(1);
+    });
+  });
+
+  describe('GET /api/snippets/:id', () => {
+    it('returns snippet by id', async () => {
+      const created = await request(app).post('/api/snippets').send({ title: 'T', code: 'c', language: 'js' });
+      const res = await request(app).get(`/api/snippets/${created.body.id}`);
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(created.body.id);
+    });
+
+    it('returns 404 for unknown id', async () => {
+      const res = await request(app).get('/api/snippets/nonexistent');
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBeTruthy();
+    });
+  });
+
+  describe('PUT /api/snippets/:id', () => {
+    it('updates a snippet', async () => {
+      const created = await request(app).post('/api/snippets').send({ title: 'Old', code: 'x', language: 'js' });
+      const res = await request(app).put(`/api/snippets/${created.body.id}`).send({ title: 'New' });
+      expect(res.status).toBe(200);
+      expect(res.body.title).toBe('New');
+    });
+
+    it('returns 404 for unknown id', async () => {
+      const res = await request(app).put('/api/snippets/bad').send({ title: 'X' });
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBeTruthy();
+    });
+
+    it('returns 400 if body is empty', async () => {
+      const created = await request(app).post('/api/snippets').send({ title: 'T', code: 'c', language: 'js' });
+      const res = await request(app).put(`/api/snippets/${created.body.id}`).send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeTruthy();
+    });
+  });
+
+  describe('DELETE /api/snippets/:id', () => {
+    it('deletes a snippet and returns 204', async () => {
+      const created = await request(app).post('/api/snippets').send({ title: 'T', code: 'c', language: 'js' });
+      const res = await request(app).delete(`/api/snippets/${created.body.id}`);
+      expect(res.status).toBe(204);
+    });
+
+    it('returns 404 for unknown id', async () => {
+      const res = await request(app).delete('/api/snippets/bad');
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Closes #13

## Changes

Implements REST API endpoints for creating, reading, updating, and deleting code snippets in `src/app.ts`.

### Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/snippets` | Create snippet (body: `title`, `code`, `language`, `description?`, `tags?`) — returns 201 or 400 |
| `GET` | `/api/snippets` | List all snippets; supports `?language=X` and `?tag=X` filters — returns `{ snippets, count }` |
| `GET` | `/api/snippets/search?q=term` | Full-text search across title, code, description, tags |
| `GET` | `/api/snippets/:id` | Get one snippet — returns snippet or 404 |
| `PUT` | `/api/snippets/:id` | Update snippet — returns updated or 404/400 |
| `DELETE` | `/api/snippets/:id` | Delete snippet — returns 204 or 404 |

All error responses: `{ error: string }`

## Tests

```
✓ src/tests/snippet-store.test.ts  (20 tests)
✓ src/tests/health.test.ts  (1 test)
✓ src/tests/snippets-api.test.ts  (13 tests)
Test Files  3 passed (3)
Tests  34 passed (34)
```

> **Note**: This PR is built on top of `repo-assist/issue-10-snippet-data-model` and should be merged after #10.

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22384540470)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22384540470, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22384540470 -->

<!-- gh-aw-workflow-id: repo-assist -->