### PR TITLE
[Pipeline] Add Tag Management API and Full-Text Search API (#11, #14)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -46,7 +46,7 @@ app.get('/api/snippets/search', (req, res) => {
     return;
   }
   const snippets = snippetStore.searchByText(q);
-  res.json({ snippets, count: snippets.length });
+  res.json({ snippets, count: snippets.length, query: q });
 });
 
 // GET /api/snippets/:id — get one
@@ -81,6 +81,18 @@ app.delete('/api/snippets/:id', (req, res) => {
     return;
   }
   res.status(204).send();
+});
+
+// GET /api/tags — list all unique tags with snippet counts
+app.get('/api/tags', (_req, res) => {
+  const tags = snippetStore.getAllTags();
+  res.json({ tags });
+});
+
+// GET /api/tags/:tag/snippets — list all snippets with a given tag
+app.get('/api/tags/:tag/snippets', (req, res) => {
+  const snippets = snippetStore.filterByTag(req.params.tag);
+  res.json({ snippets, count: snippets.length });
 });
 
 export default app;

--- a/src/tests/search-api.test.ts
+++ b/src/tests/search-api.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app, { snippetStore } from '../app';
+
+describe('Search API', () => {
+  beforeEach(() => {
+    (snippetStore as unknown as { store: Map<string, unknown> }).store.clear();
+  });
+
+  it('returns 400 if q is missing', async () => {
+    const res = await request(app).get('/api/snippets/search');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it('returns matching snippets with query field', async () => {
+    await request(app).post('/api/snippets').send({ title: 'Hello World', code: 'print("hello")', language: 'python' });
+    await request(app).post('/api/snippets').send({ title: 'Foo', code: 'x = 1', language: 'python' });
+    const res = await request(app).get('/api/snippets/search?q=hello');
+    expect(res.status).toBe(200);
+    expect(res.body.snippets).toHaveLength(1);
+    expect(res.body.count).toBe(1);
+    expect(res.body.query).toBe('hello');
+    expect(res.body.snippets[0].title).toBe('Hello World');
+  });
+
+  it('is case-insensitive', async () => {
+    await request(app).post('/api/snippets').send({ title: 'JavaScript Tips', code: 'const x = 1', language: 'js' });
+    const res = await request(app).get('/api/snippets/search?q=javascript');
+    expect(res.status).toBe(200);
+    expect(res.body.snippets).toHaveLength(1);
+  });
+
+  it('supports partial matching', async () => {
+    await request(app).post('/api/snippets').send({ title: 'TypeScript Generics', code: 'function id<T>(x: T): T { return x; }', language: 'ts' });
+    const res = await request(app).get('/api/snippets/search?q=Generic');
+    expect(res.status).toBe(200);
+    expect(res.body.snippets).toHaveLength(1);
+  });
+
+  it('returns empty array for no matches', async () => {
+    await request(app).post('/api/snippets').send({ title: 'Foo', code: 'bar', language: 'js' });
+    const res = await request(app).get('/api/snippets/search?q=zzznomatch');
+    expect(res.status).toBe(200);
+    expect(res.body.snippets).toHaveLength(0);
+    expect(res.body.count).toBe(0);
+    expect(res.body.query).toBe('zzznomatch');
+  });
+
+  it('searches in description', async () => {
+    await request(app).post('/api/snippets').send({ title: 'A', code: 'x', language: 'js', description: 'utility function for sorting' });
+    const res = await request(app).get('/api/snippets/search?q=sorting');
+    expect(res.status).toBe(200);
+    expect(res.body.snippets).toHaveLength(1);
+  });
+
+  it('searches in tags', async () => {
+    await request(app).post('/api/snippets').send({ title: 'A', code: 'x', language: 'js', tags: ['algorithms'] });
+    const res = await request(app).get('/api/snippets/search?q=algo');
+    expect(res.status).toBe(200);
+    expect(res.body.snippets).toHaveLength(1);
+  });
+});

--- a/src/tests/tags-api.test.ts
+++ b/src/tests/tags-api.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import app, { snippetStore } from '../app';
+
+describe('Tags API', () => {
+  beforeEach(() => {
+    (snippetStore as unknown as { store: Map<string, unknown> }).store.clear();
+  });
+
+  describe('GET /api/tags', () => {
+    it('returns empty tags array when no snippets', async () => {
+      const res = await request(app).get('/api/tags');
+      expect(res.status).toBe(200);
+      expect(res.body.tags).toEqual([]);
+    });
+
+    it('returns tags with counts', async () => {
+      await request(app).post('/api/snippets').send({ title: 'A', code: 'a', language: 'js', tags: ['react', 'frontend'] });
+      await request(app).post('/api/snippets').send({ title: 'B', code: 'b', language: 'ts', tags: ['react'] });
+      const res = await request(app).get('/api/tags');
+      expect(res.status).toBe(200);
+      expect(res.body.tags).toHaveLength(2);
+      const reactTag = res.body.tags.find((t: { name: string; count: number }) => t.name === 'react');
+      expect(reactTag).toBeDefined();
+      expect(reactTag.count).toBe(2);
+      const frontendTag = res.body.tags.find((t: { name: string; count: number }) => t.name === 'frontend');
+      expect(frontendTag).toBeDefined();
+      expect(frontendTag.count).toBe(1);
+    });
+  });
+
+  describe('GET /api/tags/:tag/snippets', () => {
+    it('returns snippets for a tag', async () => {
+      await request(app).post('/api/snippets').send({ title: 'A', code: 'a', language: 'js', tags: ['react'] });
+      await request(app).post('/api/snippets').send({ title: 'B', code: 'b', language: 'ts', tags: ['vue'] });
+      const res = await request(app).get('/api/tags/react/snippets');
+      expect(res.status).toBe(200);
+      expect(res.body.snippets).toHaveLength(1);
+      expect(res.body.count).toBe(1);
+      expect(res.body.snippets[0].title).toBe('A');
+    });
+
+    it('returns empty array for unknown tag', async () => {
+      const res = await request(app).get('/api/tags/nonexistent/snippets');
+      expect(res.status).toBe(200);
+      expect(res.body.snippets).toHaveLength(0);
+      expect(res.body.count).toBe(0);
+    });
+  });
+
+  describe('Tag normalization', () => {
+    it('normalizes tags to lowercase on create', async () => {
+      const res = await request(app).post('/api/snippets').send({
+        title: 'A', code: 'a', language: 'js', tags: ['React', 'FRONTEND', 'TypeScript'],
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.tags).toEqual(['react', 'frontend', 'typescript']);
+    });
+
+    it('trims whitespace from tags on create', async () => {
+      const res = await request(app).post('/api/snippets').send({
+        title: 'A', code: 'a', language: 'js', tags: ['  react  ', ' node '],
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.tags).toContain('react');
+      expect(res.body.tags).toContain('node');
+    });
+
+    it('removes duplicate tags on create', async () => {
+      const res = await request(app).post('/api/snippets').send({
+        title: 'A', code: 'a', language: 'js', tags: ['react', 'React', 'REACT'],
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.tags).toHaveLength(1);
+      expect(res.body.tags[0]).toBe('react');
+    });
+
+    it('normalizes tags on update', async () => {
+      const created = await request(app).post('/api/snippets').send({ title: 'A', code: 'a', language: 'js' });
+      const res = await request(app).put(`/api/snippets/${created.body.id}`).send({ tags: ['VUE', 'VUE', '  vue  '] });
+      expect(res.status).toBe(200);
+      expect(res.body.tags).toHaveLength(1);
+      expect(res.body.tags[0]).toBe('vue');
+    });
+  });
+});


### PR DESCRIPTION
Closes #11
Closes #14

## Changes

### Tag Management API (Issue #11)
- Added `normalizeTags()` to `SnippetStore`: normalizes tags to lowercase, trims whitespace, removes duplicates on both `create()` and `update()`
- Added `getAllTags()` method returning `[{ name, count }]` sorted alphabetically
- Added `GET /api/tags` — returns `{ tags: [{ name, count }] }`
- Added `GET /api/tags/:tag/snippets` — returns `{ snippets: [...], count: N }`

### Full-Text Search API (Issue #14)
- Fixed `GET /api/snippets/search` to include `query` field in response: `{ snippets, count, query }`

### Tests
- `src/tests/tags-api.test.ts` — 8 tests covering tag listing, tag-filtered snippets, normalization (lowercase, trim, dedup), and update normalization
- `src/tests/search-api.test.ts` — 7 tests covering 400 on missing query, case-insensitive matching, partial matching, no results, description/tag search

### Test Results
All 49 tests pass (5 test files).

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22384858568)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22384858568, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22384858568 -->

<!-- gh-aw-workflow-id: repo-assist -->