### PR TITLE
[Pipeline] Build Web UI: Snippet List & Dashboard

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,197 @@
+/* ── Variables ── */
+:root {
+  --color-bg: #f6f8fa;
+  --color-surface: #ffffff;
+  --color-border: #d0d7de;
+  --color-primary: #0969da;
+  --color-primary-hover: #0550ae;
+  --color-text: #1f2328;
+  --color-text-muted: #656d76;
+  --color-danger: #cf222e;
+  --color-code-bg: #f6f8fa;
+  --radius: 8px;
+  --shadow: 0 1px 3px rgba(0,0,0,.12), 0 1px 2px rgba(0,0,0,.08);
+  --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  --sidebar-width: 220px;
+  --header-height: 56px;
+}
+
+/* ── Reset / Base ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--color-bg); color: var(--color-text); line-height: 1.5; }
+a { color: var(--color-primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+ul { list-style: none; }
+button { cursor: pointer; font: inherit; border: none; background: none; }
+
+/* ── Header ── */
+.header {
+  position: sticky; top: 0; z-index: 100;
+  height: var(--header-height);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: var(--shadow);
+}
+.header-inner {
+  max-width: 1200px; margin: 0 auto; padding: 0 16px;
+  height: 100%; display: flex; align-items: center; gap: 16px;
+}
+.logo { font-size: 1.1rem; font-weight: 700; white-space: nowrap; }
+.header-actions { display: flex; align-items: center; gap: 10px; flex: 1; justify-content: flex-end; }
+
+/* ── Search bar ── */
+.search-bar {
+  width: 260px; max-width: 100%;
+  padding: 6px 12px; border: 1px solid var(--color-border); border-radius: 20px;
+  font-size: .9rem; background: var(--color-bg); color: var(--color-text);
+  transition: border-color .15s, box-shadow .15s;
+}
+.search-bar:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px rgba(9,105,218,.15); }
+
+/* ── Buttons ── */
+.btn-primary {
+  padding: 6px 14px; border-radius: 6px;
+  background: var(--color-primary); color: #fff; font-weight: 600; font-size: .875rem;
+  border: 1px solid transparent;
+  transition: background .15s;
+  white-space: nowrap;
+}
+.btn-primary:hover { background: var(--color-primary-hover); }
+.btn-secondary {
+  padding: 6px 14px; border-radius: 6px;
+  background: var(--color-surface); color: var(--color-text); font-weight: 600; font-size: .875rem;
+  border: 1px solid var(--color-border);
+  transition: background .15s;
+}
+.btn-secondary:hover { background: var(--color-bg); }
+
+/* ── Layout ── */
+.layout {
+  display: flex; max-width: 1200px; margin: 0 auto;
+  padding: 20px 16px; gap: 20px; min-height: calc(100vh - var(--header-height));
+}
+
+/* ── Sidebar ── */
+.sidebar {
+  width: var(--sidebar-width); flex-shrink: 0;
+}
+.sidebar-section { margin-bottom: 24px; }
+.sidebar-heading {
+  font-size: .75rem; font-weight: 700; text-transform: uppercase; letter-spacing: .05em;
+  color: var(--color-text-muted); margin-bottom: 8px;
+}
+.filter-list { display: flex; flex-direction: column; gap: 2px; }
+.filter-btn {
+  width: 100%; text-align: left; padding: 5px 8px;
+  border-radius: 5px; font-size: .875rem; color: var(--color-text);
+  transition: background .12s;
+}
+.filter-btn:hover { background: var(--color-border); }
+.filter-btn.active { background: var(--color-primary); color: #fff; font-weight: 600; }
+
+/* ── Tag cloud ── */
+.tag-cloud { display: flex; flex-wrap: wrap; gap: 6px; }
+.tag-chip {
+  padding: 2px 8px; border-radius: 12px; font-size: .78rem;
+  background: var(--color-code-bg); border: 1px solid var(--color-border);
+  color: var(--color-text); transition: background .12s, border-color .12s;
+}
+.tag-chip:hover, .tag-chip.active { background: var(--color-primary); color: #fff; border-color: var(--color-primary); }
+
+/* ── Active filter bar ── */
+.active-filter {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 12px;
+  font-size: .875rem; color: var(--color-text-muted);
+}
+.clear-filter {
+  padding: 2px 8px; border-radius: 4px; background: var(--color-border);
+  font-size: .8rem; color: var(--color-text);
+}
+.clear-filter:hover { background: var(--color-danger); color: #fff; }
+
+/* ── Snippets grid ── */
+.main-content { flex: 1; min-width: 0; }
+.snippets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+.loading { color: var(--color-text-muted); font-size: .9rem; }
+
+/* ── Snippet card ── */
+.snippet-card {
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius); box-shadow: var(--shadow);
+  display: flex; flex-direction: column; overflow: hidden;
+  transition: box-shadow .15s, transform .15s;
+}
+.snippet-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,.12); transform: translateY(-1px); }
+.card-header {
+  padding: 12px 14px 8px; display: flex; align-items: flex-start; justify-content: space-between; gap: 8px;
+}
+.card-title { font-size: .95rem; font-weight: 600; flex: 1; }
+.lang-badge {
+  padding: 2px 8px; border-radius: 12px; font-size: .72rem; font-weight: 600;
+  background: #ddf4ff; color: #0550ae; white-space: nowrap; flex-shrink: 0;
+  text-transform: lowercase;
+}
+.card-code {
+  margin: 0 14px 8px; padding: 10px 12px;
+  background: var(--color-code-bg); border-radius: 5px;
+  font-family: var(--font-mono); font-size: .78rem; line-height: 1.45;
+  overflow: hidden; max-height: 90px;
+  border: 1px solid var(--color-border);
+}
+.card-code pre { margin: 0; white-space: pre; overflow: hidden; }
+.card-footer {
+  padding: 8px 14px 12px; margin-top: auto;
+  display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 6px;
+}
+.card-tags { display: flex; flex-wrap: wrap; gap: 4px; }
+.card-timestamp { font-size: .75rem; color: var(--color-text-muted); white-space: nowrap; }
+
+/* ── Empty state ── */
+.empty-state { grid-column: 1 / -1; text-align: center; padding: 40px 0; color: var(--color-text-muted); }
+.empty-state p { margin-top: 8px; font-size: .9rem; }
+
+/* ── Modal ── */
+.modal-overlay {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(0,0,0,.45); display: flex; align-items: center; justify-content: center;
+  padding: 16px;
+}
+.modal-overlay[hidden] { display: none; }
+.modal {
+  background: var(--color-surface); border-radius: var(--radius);
+  box-shadow: 0 8px 32px rgba(0,0,0,.2);
+  width: 100%; max-width: 540px; padding: 24px;
+}
+.modal h2 { font-size: 1.1rem; margin-bottom: 16px; }
+.modal label { display: block; font-size: .85rem; font-weight: 600; margin: 10px 0 3px; }
+.required { color: var(--color-danger); }
+.modal input, .modal textarea {
+  width: 100%; padding: 7px 10px; border: 1px solid var(--color-border);
+  border-radius: 5px; font: inherit; font-size: .9rem;
+  transition: border-color .15s, box-shadow .15s;
+}
+.modal input:focus, .modal textarea:focus {
+  outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px rgba(9,105,218,.15);
+}
+.modal textarea { resize: vertical; font-family: var(--font-mono); }
+.modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+.form-error { color: var(--color-danger); font-size: .85rem; margin-top: 8px; }
+.form-error[hidden] { display: none; }
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .layout { flex-direction: column; }
+  .sidebar { width: 100%; }
+  .filter-list { flex-direction: row; flex-wrap: wrap; }
+  .search-bar { width: 160px; }
+  .snippets-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 480px) {
+  .header-inner { gap: 8px; }
+  .logo { font-size: 1rem; }
+  .search-bar { width: 120px; }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -4,9 +4,81 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Code Snippet Manager</title>
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" defer></script>
 </head>
 <body>
-  <h1>Code Snippet Manager</h1>
-  <p>Welcome to the Code Snippet Manager.</p>
+  <header class="header">
+    <div class="header-inner">
+      <h1 class="logo">Code Snippet Manager</h1>
+      <div class="header-actions">
+        <input
+          type="search"
+          id="search-input"
+          class="search-bar"
+          placeholder="Search snippets…"
+          aria-label="Search snippets"
+        >
+        <button id="new-snippet-btn" class="btn-primary">+ New Snippet</button>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <aside class="sidebar" id="sidebar">
+      <section class="sidebar-section">
+        <h2 class="sidebar-heading">Languages</h2>
+        <ul id="language-list" class="filter-list">
+          <li><button class="filter-btn active" data-language="">All</button></li>
+        </ul>
+      </section>
+      <section class="sidebar-section">
+        <h2 class="sidebar-heading">Tags</h2>
+        <div id="tag-cloud" class="tag-cloud"></div>
+      </section>
+    </aside>
+
+    <main class="main-content">
+      <div id="active-filter" class="active-filter" hidden>
+        Filtering by: <span id="filter-label"></span>
+        <button id="clear-filter-btn" class="clear-filter">✕ Clear</button>
+      </div>
+      <div id="snippets-grid" class="snippets-grid" role="list">
+        <p class="loading">Loading snippets…</p>
+      </div>
+    </main>
+  </div>
+
+  <!-- New Snippet Modal -->
+  <div id="modal-overlay" class="modal-overlay" hidden aria-modal="true" role="dialog" aria-labelledby="modal-title">
+    <div class="modal">
+      <h2 id="modal-title">New Snippet</h2>
+      <form id="new-snippet-form" novalidate>
+        <label for="f-title">Title <span class="required">*</span></label>
+        <input id="f-title" name="title" type="text" required placeholder="e.g. Debounce function">
+
+        <label for="f-language">Language</label>
+        <input id="f-language" name="language" type="text" placeholder="e.g. javascript">
+
+        <label for="f-description">Description</label>
+        <input id="f-description" name="description" type="text" placeholder="Short description">
+
+        <label for="f-tags">Tags (comma-separated)</label>
+        <input id="f-tags" name="tags" type="text" placeholder="e.g. utils, async">
+
+        <label for="f-code">Code <span class="required">*</span></label>
+        <textarea id="f-code" name="code" rows="8" required placeholder="Paste your code here…"></textarea>
+
+        <div class="modal-actions">
+          <button type="button" id="modal-cancel-btn" class="btn-secondary">Cancel</button>
+          <button type="submit" class="btn-primary">Save Snippet</button>
+        </div>
+        <p id="form-error" class="form-error" hidden></p>
+      </form>
+    </div>
+  </div>
+
+  <script src="js/app.js"></script>
 </body>
 </html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,321 @@
+/**
+ * Code Snippet Manager — client-side app (no framework)
+ */
+
+// ── State ─────────────────────────────────────────────────────────────────────
+let activeLanguage = '';
+let activeTag = '';
+let searchDebounceTimer = null;
+
+// ── DOM refs ──────────────────────────────────────────────────────────────────
+const snippetsGrid   = document.getElementById('snippets-grid');
+const languageList   = document.getElementById('language-list');
+const tagCloud       = document.getElementById('tag-cloud');
+const searchInput    = document.getElementById('search-input');
+const newSnippetBtn  = document.getElementById('new-snippet-btn');
+const modalOverlay   = document.getElementById('modal-overlay');
+const modalCancelBtn = document.getElementById('modal-cancel-btn');
+const newSnippetForm = document.getElementById('new-snippet-form');
+const formError      = document.getElementById('form-error');
+const activeFilterEl = document.getElementById('active-filter');
+const filterLabel    = document.getElementById('filter-label');
+const clearFilterBtn = document.getElementById('clear-filter-btn');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a human-readable relative time string (e.g. "3 minutes ago").
+ * @param {string} isoString
+ * @returns {string}
+ */
+function relativeTime(isoString) {
+  const diffMs = Date.now() - new Date(isoString).getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} minute${diffMin !== 1 ? 's' : ''} ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr} hour${diffHr !== 1 ? 's' : ''} ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay} day${diffDay !== 1 ? 's' : ''} ago`;
+}
+
+/**
+ * Returns the first `n` lines of a string.
+ * @param {string} code
+ * @param {number} n
+ * @returns {string}
+ */
+function firstLines(code, n) {
+  return code.split('\n').slice(0, n).join('\n');
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+/**
+ * Renders a single snippet card element.
+ * @param {object} snippet
+ * @returns {HTMLElement}
+ */
+function renderCard(snippet) {
+  const card = document.createElement('article');
+  card.className = 'snippet-card';
+  card.setAttribute('role', 'listitem');
+
+  const preview = firstLines(snippet.code, 4);
+  const langBadge = snippet.language
+    ? `<span class="lang-badge">${escapeHtml(snippet.language)}</span>`
+    : '';
+
+  const tagsHtml = (snippet.tags || [])
+    .map(
+      (t) =>
+        `<button class="tag-chip" data-tag="${escapeHtml(t)}" aria-label="Filter by tag ${escapeHtml(t)}">${escapeHtml(t)}</button>`
+    )
+    .join('');
+
+  card.innerHTML = `
+    <div class="card-header">
+      <span class="card-title">${escapeHtml(snippet.title)}</span>
+      ${langBadge}
+    </div>
+    <div class="card-code">
+      <pre><code class="language-${escapeHtml(snippet.language || 'plaintext')}">${escapeHtml(preview)}</code></pre>
+    </div>
+    <div class="card-footer">
+      <div class="card-tags">${tagsHtml}</div>
+      <span class="card-timestamp" title="${escapeHtml(snippet.createdAt)}">${relativeTime(snippet.createdAt)}</span>
+    </div>
+  `;
+
+  // Highlight code block
+  const codeEl = card.querySelector('code');
+  if (window.hljs && codeEl) window.hljs.highlightElement(codeEl);
+
+  // Tag chip click → filter
+  card.querySelectorAll('.tag-chip').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      setTagFilter(btn.dataset.tag);
+    });
+  });
+
+  return card;
+}
+
+/**
+ * Renders the snippet grid with the given array.
+ * @param {object[]} snippets
+ */
+function renderSnippets(snippets) {
+  snippetsGrid.innerHTML = '';
+  if (!snippets || snippets.length === 0) {
+    snippetsGrid.innerHTML = `
+      <div class="empty-state">
+        <strong>No snippets found</strong>
+        <p>Try a different filter or search term.</p>
+      </div>`;
+    return;
+  }
+  snippets.forEach((s) => snippetsGrid.appendChild(renderCard(s)));
+}
+
+/**
+ * Rebuilds the language filter sidebar.
+ * @param {object[]} snippets  — full unfiltered list
+ */
+function renderLanguageSidebar(snippets) {
+  const langs = [...new Set(snippets.map((s) => s.language).filter(Boolean))].sort();
+  languageList.innerHTML = `<li><button class="filter-btn${!activeLanguage ? ' active' : ''}" data-language="">All</button></li>`;
+  langs.forEach((lang) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<button class="filter-btn${activeLanguage === lang ? ' active' : ''}" data-language="${escapeHtml(lang)}">${escapeHtml(lang)}</button>`;
+    languageList.appendChild(li);
+  });
+  languageList.querySelectorAll('.filter-btn').forEach((btn) => {
+    btn.addEventListener('click', () => setLanguageFilter(btn.dataset.language));
+  });
+}
+
+/**
+ * Renders the tag cloud sidebar from /api/tags.
+ */
+async function renderTagCloud() {
+  try {
+    const res = await fetch('/api/tags');
+    if (!res.ok) return;
+    const { tags } = await res.json();
+    tagCloud.innerHTML = '';
+    tags.forEach(({ name }) => {
+      const btn = document.createElement('button');
+      btn.className = `tag-chip${activeTag === name ? ' active' : ''}`;
+      btn.dataset.tag = name;
+      btn.textContent = name;
+      btn.setAttribute('aria-label', `Filter by tag ${name}`);
+      btn.addEventListener('click', () => setTagFilter(name));
+      tagCloud.appendChild(btn);
+    });
+  } catch (_) {
+    // silently ignore tag cloud errors
+  }
+}
+
+// ── Filter / search ───────────────────────────────────────────────────────────
+
+function updateActiveFilterBar() {
+  if (activeLanguage || activeTag || searchInput.value.trim()) {
+    let label = '';
+    if (searchInput.value.trim()) label = `"${searchInput.value.trim()}"`;
+    else if (activeLanguage) label = `language: ${activeLanguage}`;
+    else if (activeTag) label = `tag: ${activeTag}`;
+    filterLabel.textContent = label;
+    activeFilterEl.hidden = false;
+  } else {
+    activeFilterEl.hidden = true;
+  }
+}
+
+function setLanguageFilter(lang) {
+  activeLanguage = lang;
+  activeTag = '';
+  searchInput.value = '';
+  updateActiveFilterBar();
+  loadSnippets();
+}
+
+function setTagFilter(tag) {
+  activeTag = tag;
+  activeLanguage = '';
+  searchInput.value = '';
+  updateActiveFilterBar();
+  loadSnippets();
+}
+
+function clearFilters() {
+  activeLanguage = '';
+  activeTag = '';
+  searchInput.value = '';
+  updateActiveFilterBar();
+  loadSnippets();
+}
+
+// ── Data fetching ─────────────────────────────────────────────────────────────
+
+async function loadSnippets() {
+  try {
+    const q = searchInput.value.trim();
+    let url;
+    if (q) {
+      url = `/api/snippets/search?q=${encodeURIComponent(q)}`;
+    } else if (activeLanguage) {
+      url = `/api/snippets?language=${encodeURIComponent(activeLanguage)}`;
+    } else if (activeTag) {
+      url = `/api/tags/${encodeURIComponent(activeTag)}/snippets`;
+    } else {
+      url = '/api/snippets';
+    }
+
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const snippets = data.snippets || [];
+    renderSnippets(snippets);
+
+    // Rebuild language sidebar only on full list (no filter)
+    if (!q && !activeLanguage && !activeTag) {
+      renderLanguageSidebar(snippets);
+      await renderTagCloud();
+    }
+  } catch (err) {
+    snippetsGrid.innerHTML = `<p class="loading">Error loading snippets: ${escapeHtml(err.message)}</p>`;
+  }
+}
+
+// ── Search (debounced) ────────────────────────────────────────────────────────
+
+searchInput.addEventListener('input', () => {
+  clearTimeout(searchDebounceTimer);
+  activeLanguage = '';
+  activeTag = '';
+  updateActiveFilterBar();
+  searchDebounceTimer = setTimeout(loadSnippets, 300);
+});
+
+// ── New Snippet modal ─────────────────────────────────────────────────────────
+
+function openModal() {
+  newSnippetForm.reset();
+  formError.hidden = true;
+  modalOverlay.hidden = false;
+  document.getElementById('f-title').focus();
+}
+
+function closeModal() {
+  modalOverlay.hidden = true;
+}
+
+newSnippetBtn.addEventListener('click', openModal);
+modalCancelBtn.addEventListener('click', closeModal);
+modalOverlay.addEventListener('click', (e) => {
+  if (e.target === modalOverlay) closeModal();
+});
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && !modalOverlay.hidden) closeModal();
+});
+
+newSnippetForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  formError.hidden = true;
+
+  const title = newSnippetForm.title.value.trim();
+  const code  = newSnippetForm.code.value;
+  if (!title || !code.trim()) {
+    formError.textContent = 'Title and code are required.';
+    formError.hidden = false;
+    return;
+  }
+
+  const tagsRaw = newSnippetForm.tags.value.trim();
+  const tags = tagsRaw ? tagsRaw.split(',').map((t) => t.trim()).filter(Boolean) : [];
+
+  const payload = {
+    title,
+    code,
+    language: newSnippetForm.language.value.trim(),
+    description: newSnippetForm.description.value.trim(),
+    tags,
+  };
+
+  try {
+    const res = await fetch('/api/snippets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const body = await res.json();
+      throw new Error(body.error || `HTTP ${res.status}`);
+    }
+    closeModal();
+    clearFilters();
+  } catch (err) {
+    formError.textContent = err.message;
+    formError.hidden = false;
+  }
+});
+
+// ── Clear filter button ───────────────────────────────────────────────────────
+
+clearFilterBtn.addEventListener('click', clearFilters);
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+
+loadSnippets();


### PR DESCRIPTION
Closes #8

## Changes

Implements the main snippet list / dashboard web UI as a set of plain HTML + CSS + JS files (no framework).

### Files Changed
- **`public/index.html`** — full responsive layout: header, sidebar, main grid, New Snippet modal
- **`public/css/style.css`** — CSS-variable theming, card-based grid, monospace code previews, mobile breakpoints (768 px, 480 px)
- **`public/js/app.js`** — client-side logic: fetch-based data loading, language/tag filtering, debounced search, New Snippet form

### Acceptance Criteria Addressed
- ✅ Responsive layout with header, sidebar (language filter + tag cloud), and main content area
- ✅ Snippet cards: title, language badge, first 4 lines of code preview, tag chips, relative timestamp
- ✅ Language filter list in sidebar (populated from snippet data)
- ✅ Tag cloud in sidebar (populated from `GET /api/tags`)
- ✅ Clicking a language or tag filters the list (client-side fetch to API)
- ✅ Debounced search bar (300 ms) calling `GET /api/snippets/search`
- ✅ "New Snippet" button opens modal that POSTs to `GET /api/snippets`
- ✅ Mobile-responsive (CSS breakpoints at 768 px and 480 px)
- ✅ Uses highlight.js (CDN) for code highlighting

### Test Results
All 49 existing tests pass — no regressions.

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22385066285)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22385066285, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22385066285 -->

<!-- gh-aw-workflow-id: repo-assist -->