### PR TITLE
[Pipeline] Navigation Bar and Landing Page with View Cards

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import NavBar from "@/components/nav-bar";
 
 export const metadata: Metadata = {
   title: "Pipeline Observatory",
@@ -14,7 +15,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="dark bg-gray-950 text-gray-100 min-h-screen font-sans">
-        {children}
+        <NavBar />
+        <main>{children}</main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,65 @@
-export default function Home() {
+import Link from "next/link";
+import { getPipelineData } from "@/data/index";
+
+const viewCards = [
+  {
+    href: "/simulator",
+    title: "Simulator",
+    description: "Explore how the pipeline works",
+  },
+  {
+    href: "/replay",
+    title: "Replay",
+    description: "Watch the Code Snippet Manager run",
+  },
+  {
+    href: "/forensics",
+    title: "Forensics",
+    description: "Inspect agent decisions and reviews",
+  },
+];
+
+export default async function Home() {
+  const data = await getPipelineData();
+
+  const featuresShipped = data.issues.filter(
+    (i) => i.state === "closed" && i.labels.some((l) => l.name === "feature")
+  ).length;
+  const prsMerged = data.pullRequests.filter((pr) => pr.state === "merged").length;
+
   return (
-    <main>
-      <h1>Pipeline Observatory</h1>
-    </main>
+    <div>
+      {/* Hero */}
+      <section className="bg-gradient-to-b from-gray-900 to-gray-950 py-24 px-6 text-center">
+        <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
+          Pipeline Observatory
+        </h1>
+        <p className="text-lg text-gray-400 max-w-xl mx-auto">
+          Visualize, replay, and inspect an autonomous AI development pipeline
+        </p>
+      </section>
+
+      {/* View cards */}
+      <section className="max-w-5xl mx-auto px-6 py-12 grid grid-cols-1 md:grid-cols-3 gap-6">
+        {viewCards.map(({ href, title, description }) => (
+          <Link
+            key={href}
+            href={href}
+            className="block rounded-xl bg-gray-900 border border-gray-800 p-8 hover:bg-gray-800 transition-colors"
+          >
+            <h2 className="text-xl font-semibold text-white mb-2">{title}</h2>
+            <p className="text-gray-400">{description}</p>
+          </Link>
+        ))}
+      </section>
+
+      {/* Stats bar */}
+      <section className="max-w-5xl mx-auto px-6 pb-16 flex flex-wrap gap-8 justify-center text-gray-400 text-sm">
+        <span>{featuresShipped} features shipped</span>
+        <span>{prsMerged} PRs merged</span>
+        <span>~2 hours end-to-end</span>
+      </section>
+    </div>
   );
 }
+

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const navLinks = [
+  { href: "/simulator", label: "Simulator" },
+  { href: "/replay", label: "Replay" },
+  { href: "/forensics", label: "Forensics" },
+];
+
+export default function NavBar() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="sticky top-0 z-50 h-16 bg-gray-900 flex items-center px-6 shadow-md">
+      <span className="text-lg font-semibold text-white mr-auto">
+        Pipeline Observatory
+      </span>
+      <div className="flex gap-6">
+        {navLinks.map(({ href, label }) => (
+          <Link
+            key={href}
+            href={href}
+            className={
+              pathname === href
+                ? "text-white font-medium border-b-2 border-indigo-400 pb-0.5"
+                : "text-gray-400 hover:text-white transition-colors"
+            }
+          >
+            {label}
+          </Link>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/src/test/home.test.tsx
+++ b/src/test/home.test.tsx
@@ -1,10 +1,53 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import Home from "@/app/page";
+import { getPipelineData } from "@/data/index";
+
+vi.mock("@/data/index");
+
+const mockData = {
+  issues: [
+    {
+      number: 1,
+      title: "Feature A",
+      state: "closed" as const,
+      createdAt: "",
+      closedAt: "2026-01-01",
+      labels: [{ name: "feature", color: "green" }],
+    },
+  ],
+  pullRequests: [
+    {
+      number: 1,
+      title: "PR A",
+      state: "merged" as const,
+      createdAt: "",
+      mergedAt: "2026-01-02",
+      additions: 10,
+      deletions: 2,
+      changedFiles: 1,
+      reviews: [],
+    },
+  ],
+  workflowRuns: [],
+};
 
 describe("Home page", () => {
-  it("renders Pipeline Observatory heading", () => {
-    render(<Home />);
-    expect(screen.getByRole("heading", { name: /pipeline observatory/i })).toBeInTheDocument();
+  it("renders Pipeline Observatory heading", async () => {
+    vi.mocked(getPipelineData).mockResolvedValue(mockData);
+    render(await Home());
+    expect(screen.getByRole("heading", { name: /pipeline observatory/i, level: 1 })).toBeInTheDocument();
+  });
+
+  it("renders three view cards with correct hrefs", async () => {
+    vi.mocked(getPipelineData).mockResolvedValue(mockData);
+    render(await Home());
+    const simulatorLink = screen.getByRole("link", { name: /simulator/i });
+    const replayLink = screen.getByRole("link", { name: /replay/i });
+    const forensicsLink = screen.getByRole("link", { name: /forensics/i });
+    expect(simulatorLink).toHaveAttribute("href", "/simulator");
+    expect(replayLink).toHaveAttribute("href", "/replay");
+    expect(forensicsLink).toHaveAttribute("href", "/forensics");
   });
 });
+


### PR DESCRIPTION
Closes #32

## Changes

### `src/components/nav-bar.tsx` (new)
Client Component using `usePathname` for active-link highlighting. Sticky `h-16 bg-gray-900` nav with "Pipeline Observatory" logo on the left and links to `/simulator`, `/replay`, `/forensics` on the right.

### `src/app/layout.tsx`
Added `(NavBar /)` above all page content inside a `(main)` wrapper.

### `src/app/page.tsx`
Updated to an async Server Component that calls `getPipelineData()` at build time:
- **Hero section**: large heading + subtitle on a dark gradient background
- **Three view cards** in `grid-cols-1 md:grid-cols-3`: Simulator, Replay, Forensics with correct `href` links and `hover:bg-gray-800 transition-colors`
- **Stats bar**: features shipped + PRs merged computed from fixture data, plus "~2 hours end-to-end"

### `src/test/home.test.tsx`
Updated to mock `getPipelineData` and added assertions for the three card links with correct `href` attributes.

## Test Results
All 8 tests pass:
```
✓ src/test/data.test.ts  (6 tests)
✓ src/test/home.test.tsx  (2 tests)
```

> **Note**: There is a pre-existing TypeScript build error in `src/data/github.ts` (Octokit list endpoint missing `additions`/`deletions` fields). This is unrelated to this PR.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22397198795)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22397198795, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22397198795 -->

<!-- gh-aw-workflow-id: repo-assist -->