### PR TITLE
[Pipeline] Scale simulator pipeline graph and nodes to fill the screen

### DIFF
--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -3,7 +3,7 @@ import SimulatorControls from "@/components/simulator/simulator-controls";
 export default function SimulatorPage() {
   return (
     <main className="min-h-screen bg-gray-950 py-12 px-6">
-      <div className="max-w-4xl mx-auto">
+      <div className="w-full max-w-screen-2xl mx-auto">
         <h1 className="text-3xl font-bold text-white mb-2">Pipeline Simulator</h1>
         <p className="text-gray-400 mb-10">
           Click <span className="text-blue-400 font-medium">"PRD Decomposer"</span> to start the

--- a/src/components/simulator/pipeline-graph.tsx
+++ b/src/components/simulator/pipeline-graph.tsx
@@ -6,10 +6,10 @@ import { MessageParticle, ParticleType } from "./message-particle";
 
 // Node data
 const NODES = [
-  { id: "decomposer", label: "PRD Decomposer", icon: "📋", cx: 112, cy: 100 },
-  { id: "assist", label: "Repo Assist", icon: "🤖", cx: 337, cy: 100 },
-  { id: "reviewer", label: "PR Reviewer", icon: "🔍", cx: 562, cy: 100 },
-  { id: "merge", label: "Auto-Merge", icon: "✅", cx: 787, cy: 100 },
+  { id: "decomposer", label: "PRD Decomposer", icon: "📋", cx: 150, cy: 150 },
+  { id: "assist", label: "Repo Assist", icon: "🤖", cx: 450, cy: 150 },
+  { id: "reviewer", label: "PR Reviewer", icon: "🔍", cx: 750, cy: 150 },
+  { id: "merge", label: "Auto-Merge", icon: "✅", cx: 1050, cy: 150 },
 ] as const;
 
 type NodeId = (typeof NODES)[number]["id"];
@@ -20,16 +20,16 @@ const NODE_SEQUENCE: NodeId[] = ["decomposer", "assist", "reviewer", "merge"];
 // Curved path between consecutive nodes
 function forwardPath(x1: number, x2: number, y: number): string {
   const mx = (x1 + x2) / 2;
-  return `M ${x1 + 75} ${y} C ${mx} ${y}, ${mx} ${y}, ${x2 - 75} ${y}`;
+  return `M ${x1 + 100} ${y} C ${mx} ${y}, ${mx} ${y}, ${x2 - 100} ${y}`;
 }
 
 // Dashed return path: Merge → Assist (below the nodes)
-const RETURN_PATH = `M 787 ${100 + 45} C 787 165, 337 165, 337 ${100 + 45}`;
+const RETURN_PATH = `M 1050 ${150 + 55} C 1050 245, 450 245, 450 ${150 + 55}`;
 
 const EDGE_PATHS = [
-  forwardPath(112, 337, 100),
-  forwardPath(337, 562, 100),
-  forwardPath(562, 787, 100),
+  forwardPath(150, 450, 150),
+  forwardPath(450, 750, 150),
+  forwardPath(750, 1050, 150),
   RETURN_PATH,
 ];
 
@@ -109,10 +109,10 @@ export function PipelineGraph({ speed, onNodeSelect }: PipelineGraphProps) {
   }
 
   return (
-    <div className="flex flex-col items-center gap-6">
+    <div className="w-full flex flex-col items-center gap-6">
       <svg
-        viewBox="0 0 900 200"
-        className="w-full max-w-3xl"
+        viewBox="0 0 1200 300"
+        className="w-full"
         aria-label="Pipeline node graph"
         role="img"
       >
@@ -157,25 +157,25 @@ export function PipelineGraph({ speed, onNodeSelect }: PipelineGraphProps) {
               role="button"
             >
               <motion.rect
-                x={cx - 75}
-                y={cy - 40}
-                width={150}
-                height={80}
-                rx={12}
+                x={cx - 100}
+                y={cy - 55}
+                width={200}
+                height={110}
+                rx={14}
                 fill="#1f2937"
                 stroke={borderColor(s)}
                 strokeWidth={2}
                 animate={{ stroke: borderColor(s), filter: glowFilter(s) }}
                 transition={{ duration: 0.3 }}
               />
-              <text x={cx} y={cy - 10} textAnchor="middle" fontSize={22} dominantBaseline="middle">
+              <text x={cx} y={cy - 14} textAnchor="middle" fontSize={30} dominantBaseline="middle">
                 {icon}
               </text>
               <text
                 x={cx}
-                y={cy + 18}
+                y={cy + 24}
                 textAnchor="middle"
-                fontSize={11}
+                fontSize={14}
                 fill={s === "idle" ? "#9ca3af" : "#f9fafb"}
                 dominantBaseline="middle"
               >
@@ -185,9 +185,9 @@ export function PipelineGraph({ speed, onNodeSelect }: PipelineGraphProps) {
                 {s === "completed" && (
                   <motion.text
                     key="check"
-                    x={cx + 58}
-                    y={cy - 28}
-                    fontSize={14}
+                    x={cx + 78}
+                    y={cy - 43}
+                    fontSize={18}
                     initial={{ opacity: 0, scale: 0 }}
                     animate={{ opacity: 1, scale: 1 }}
                     exit={{ opacity: 0 }}

--- a/src/components/simulator/simulator-controls.tsx
+++ b/src/components/simulator/simulator-controls.tsx
@@ -13,7 +13,7 @@ export default function SimulatorControls() {
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
 
   return (
-    <div className="flex flex-col items-center gap-8">
+    <div className="w-full flex flex-col items-center gap-8">
       <PipelineGraph key={resetKey} speed={speed} onNodeSelect={setSelectedNode} />
 
       <NodeDetail nodeId={selectedNode} onClose={() => setSelectedNode(null)} />


### PR DESCRIPTION
Closes #57

## Changes

Scales the interactive SVG pipeline graph on `/simulator` to fill the available screen width and be significantly more readable.

### What changed

**`src/components/simulator/pipeline-graph.tsx`**
- Expanded SVG `viewBox` from `900×200` → `1200×300` for more vertical and horizontal space
- Redistributed node centres to `cx: 150, 450, 750, 1050` (even 300 px spacing, 50 px margins)
- Enlarged node rectangles from `150×80` → `200×110` (rx 12→14)
- Increased icon `fontSize` 22→30 and label `fontSize` 11→14 for legibility
- Updated `forwardPath` half-width offset 75→100 and `RETURN_PATH` to match new geometry
- Removed `max-w-3xl` constraint from the SVG element; now `w-full`
- Added `w-full` to the wrapper `(div)`

**`src/app/simulator/page.tsx`**
- Widened page container from `max-w-4xl` → `max-w-screen-2xl` so the graph can fill large screens

**`src/components/simulator/simulator-controls.tsx`**
- Added `w-full` to the outer wrapper div so the graph receives full container width

### Test results

All 32 existing Vitest tests pass. Production build succeeds with no TypeScript errors.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22415823933) for issue #57

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22415823933, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22415823933 -->

<!-- gh-aw-workflow-id: repo-assist -->