### PR TITLE
[Pipeline] GitHub Data Layer — Types, Fixtures, and API Fetching

### DIFF
--- a/src/data/__tests__/github.test.ts
+++ b/src/data/__tests__/github.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { getDevCardData } from "../index";
+import type { DevCardData } from "../types";
+
+// Mock the github module so tests don't make real API calls
+vi.mock("../github", () => ({
+  fetchGitHubUser: vi.fn().mockRejectedValue(new Error("API unavailable")),
+}));
+
+describe("getDevCardData", () => {
+  it("returns fixture data for 'octocat' when the API throws", async () => {
+    const data = await getDevCardData("octocat");
+    expect(data.user.login).toBe("octocat");
+    expect(data.topRepos).toBeInstanceOf(Array);
+    expect(data.languages).toBeInstanceOf(Array);
+    expect(typeof data.contributions.totalContributions).toBe("number");
+  });
+
+  it("throws for non-octocat usernames when the API fails", async () => {
+    await expect(getDevCardData("nonexistent-user-xyz")).rejects.toThrow();
+  });
+});
+
+describe("fixture data shape", () => {
+  it("fixture JSON parses correctly and satisfies the DevCardData shape", async () => {
+    const data = await getDevCardData("octocat");
+    const d = data as DevCardData;
+
+    // user fields
+    expect(typeof d.user.login).toBe("string");
+    expect(typeof d.user.publicRepos).toBe("number");
+    expect(typeof d.user.followers).toBe("number");
+    expect(typeof d.user.following).toBe("number");
+    expect(typeof d.user.createdAt).toBe("string");
+
+    // topRepos
+    expect(d.topRepos.length).toBeGreaterThan(0);
+    const repo = d.topRepos[0];
+    expect(typeof repo.name).toBe("string");
+    expect(typeof repo.stargazerCount).toBe("number");
+    expect(Array.isArray(repo.topics)).toBe(true);
+
+    // languages
+    expect(d.languages.length).toBeGreaterThan(0);
+    const totalPct = d.languages.reduce((s, l) => s + l.percentage, 0);
+    expect(totalPct).toBe(100);
+
+    // contributions
+    expect(typeof d.contributions.totalContributions).toBe("number");
+    expect(typeof d.contributions.currentStreak).toBe("number");
+    expect(typeof d.contributions.longestStreak).toBe("number");
+    expect(typeof d.contributions.contributionsLastYear).toBe("number");
+  });
+});

--- a/src/data/fixtures/sample-user.json
+++ b/src/data/fixtures/sample-user.json
@@ -1,0 +1,92 @@
+{
+  "user": {
+    "login": "octocat",
+    "name": "The Octocat",
+    "avatarUrl": "https://avatars.githubusercontent.com/u/583231?v=4",
+    "bio": "A mysterious entity that loves Git.",
+    "company": "@github",
+    "location": "San Francisco, CA",
+    "blog": "https://github.blog",
+    "twitterUsername": null,
+    "publicRepos": 8,
+    "followers": 15000,
+    "following": 9,
+    "createdAt": "2011-01-25T18:44:36Z"
+  },
+  "topRepos": [
+    {
+      "name": "Hello-World",
+      "description": "My first repository on GitHub!",
+      "language": "JavaScript",
+      "stargazerCount": 2300,
+      "forkCount": 1800,
+      "updatedAt": "2024-01-01T00:00:00Z",
+      "url": "https://github.com/octocat/Hello-World",
+      "topics": ["sample", "git"]
+    },
+    {
+      "name": "Spoon-Knife",
+      "description": "This repo is for demonstration purposes only.",
+      "language": "HTML",
+      "stargazerCount": 12000,
+      "forkCount": 130000,
+      "updatedAt": "2024-02-15T00:00:00Z",
+      "url": "https://github.com/octocat/Spoon-Knife",
+      "topics": ["fork-me"]
+    },
+    {
+      "name": "linguist",
+      "description": "Language Savant.",
+      "language": "Ruby",
+      "stargazerCount": 1200,
+      "forkCount": 400,
+      "updatedAt": "2024-03-10T00:00:00Z",
+      "url": "https://github.com/octocat/linguist",
+      "topics": ["language-detection"]
+    },
+    {
+      "name": "octocat.github.io",
+      "description": "octocat's personal website",
+      "language": "HTML",
+      "stargazerCount": 800,
+      "forkCount": 200,
+      "updatedAt": "2024-04-05T00:00:00Z",
+      "url": "https://github.com/octocat/octocat.github.io",
+      "topics": []
+    },
+    {
+      "name": "git-consortium",
+      "description": "This repo is for demonstration purposes only.",
+      "language": "TypeScript",
+      "stargazerCount": 350,
+      "forkCount": 80,
+      "updatedAt": "2024-05-20T00:00:00Z",
+      "url": "https://github.com/octocat/git-consortium",
+      "topics": []
+    },
+    {
+      "name": "boysenberry-repo-1",
+      "description": "Testing.",
+      "language": "Python",
+      "stargazerCount": 120,
+      "forkCount": 50,
+      "updatedAt": "2024-06-01T00:00:00Z",
+      "url": "https://github.com/octocat/boysenberry-repo-1",
+      "topics": []
+    }
+  ],
+  "languages": [
+    { "name": "JavaScript", "percentage": 35, "color": "#f1e05a", "bytes": 52000 },
+    { "name": "HTML", "percentage": 28, "color": "#e34c26", "bytes": 41600 },
+    { "name": "Ruby", "percentage": 18, "color": "#701516", "bytes": 26800 },
+    { "name": "TypeScript", "percentage": 12, "color": "#3178c6", "bytes": 17900 },
+    { "name": "Python", "percentage": 4, "color": "#3572A5", "bytes": 5950 },
+    { "name": "CSS", "percentage": 3, "color": "#563d7c", "bytes": 4500 }
+  ],
+  "contributions": {
+    "totalContributions": 1247,
+    "currentStreak": 7,
+    "longestStreak": 42,
+    "contributionsLastYear": 487
+  }
+}

--- a/src/data/github.ts
+++ b/src/data/github.ts
@@ -1,0 +1,103 @@
+import { Octokit } from "@octokit/rest";
+import type { DevCardData, GitHubRepo, LanguageStat } from "./types";
+
+const LANGUAGE_COLORS: Record<string, string> = {
+  JavaScript: "#f1e05a",
+  TypeScript: "#3178c6",
+  Python: "#3572A5",
+  Ruby: "#701516",
+  Java: "#b07219",
+  Go: "#00ADD8",
+  Rust: "#dea584",
+  "C++": "#f34b7d",
+  C: "#555555",
+  HTML: "#e34c26",
+  CSS: "#563d7c",
+  Shell: "#89e051",
+  Swift: "#fa7343",
+  Kotlin: "#A97BFF",
+  PHP: "#4F5D95",
+};
+
+export async function fetchGitHubUser(username: string): Promise<DevCardData> {
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_TOKEN,
+  });
+
+  const { data: userRaw } = await octokit.users.getByUsername({ username });
+
+  const user = {
+    login: userRaw.login,
+    name: userRaw.name ?? null,
+    avatarUrl: userRaw.avatar_url,
+    bio: userRaw.bio ?? null,
+    company: userRaw.company ?? null,
+    location: userRaw.location ?? null,
+    blog: userRaw.blog ?? null,
+    twitterUsername: userRaw.twitter_username ?? null,
+    publicRepos: userRaw.public_repos,
+    followers: userRaw.followers,
+    following: userRaw.following,
+    createdAt: userRaw.created_at,
+  };
+
+  const { data: reposRaw } = await octokit.repos.listForUser({
+    username,
+    sort: "updated",
+    per_page: 20,
+  });
+
+  const topRepos: GitHubRepo[] = reposRaw
+    .sort((a, b) => (b.stargazers_count ?? 0) - (a.stargazers_count ?? 0))
+    .map((r) => ({
+    name: r.name,
+    description: r.description ?? null,
+    language: r.language ?? null,
+    stargazerCount: r.stargazers_count ?? 0,
+    forkCount: r.forks_count ?? 0,
+    updatedAt: r.updated_at ?? new Date().toISOString(),
+    url: r.html_url,
+    topics: r.topics ?? [],
+  }));
+
+  // Aggregate language bytes from top 6 repos
+  const languageBytesMap: Record<string, number> = {};
+  const top6Repos = reposRaw.slice(0, 6);
+  await Promise.all(
+    top6Repos.map(async (repo) => {
+      try {
+        const { data: langs } = await octokit.repos.listLanguages({
+          owner: username,
+          repo: repo.name,
+        });
+        for (const [lang, bytes] of Object.entries(langs)) {
+          languageBytesMap[lang] = (languageBytesMap[lang] ?? 0) + bytes;
+        }
+      } catch {
+        // ignore individual repo language fetch errors
+      }
+    })
+  );
+
+  const totalBytes = Object.values(languageBytesMap).reduce((s, b) => s + b, 0);
+  const languages: LanguageStat[] = Object.entries(languageBytesMap)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([name, bytes]) => ({
+      name,
+      percentage: totalBytes > 0 ? Math.round((bytes / totalBytes) * 100) : 0,
+      color: LANGUAGE_COLORS[name] ?? "#8b949e",
+      bytes,
+    }));
+
+  // Heuristic contribution stats (GraphQL endpoint out of scope)
+  const totalContributions = userRaw.public_repos * 50 + userRaw.followers * 2;
+  const contributions = {
+    totalContributions,
+    currentStreak: Math.min(userRaw.public_repos, 14),
+    longestStreak: Math.min(userRaw.public_repos * 3, 90),
+    contributionsLastYear: Math.round(totalContributions * 0.4),
+  };
+
+  return { user, topRepos, languages, contributions };
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,18 @@
+import { fetchGitHubUser } from "./github";
+import type { DevCardData } from "./types";
+import fixture from "@/data/fixtures/sample-user.json";
+
+export async function getDevCardData(username: string): Promise<DevCardData> {
+  try {
+    const data = await fetchGitHubUser(username);
+    console.log(`[DevCard] Loaded live API data for "${username}"`);
+    return data;
+  } catch (err) {
+    if (username === "octocat") {
+      console.log(`[DevCard] API error for "octocat", falling back to fixture data`);
+      return fixture as DevCardData;
+    }
+    console.error(`[DevCard] Failed to fetch data for "${username}":`, err);
+    throw err;
+  }
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,0 +1,46 @@
+export interface GitHubUser {
+  login: string;
+  name: string | null;
+  avatarUrl: string;
+  bio: string | null;
+  company: string | null;
+  location: string | null;
+  blog: string | null;
+  twitterUsername: string | null;
+  publicRepos: number;
+  followers: number;
+  following: number;
+  createdAt: string;
+}
+
+export interface GitHubRepo {
+  name: string;
+  description: string | null;
+  language: string | null;
+  stargazerCount: number;
+  forkCount: number;
+  updatedAt: string;
+  url: string;
+  topics: string[];
+}
+
+export interface LanguageStat {
+  name: string;
+  percentage: number;
+  color: string;
+  bytes: number;
+}
+
+export interface ContributionStats {
+  totalContributions: number;
+  currentStreak: number;
+  longestStreak: number;
+  contributionsLastYear: number;
+}
+
+export interface DevCardData {
+  user: GitHubUser;
+  topRepos: GitHubRepo[];
+  languages: LanguageStat[];
+  contributions: ContributionStats;
+}


### PR DESCRIPTION
Closes #64

## Summary

Implements the GitHub data-fetching layer for the DevCard app.

### Files Added

- **`src/data/types.ts`** — TypeScript interfaces: `GitHubUser`, `GitHubRepo`, `LanguageStat`, `ContributionStats`, `DevCardData` (all exported)
- **`src/data/fixtures/sample-user.json`** — Fixture data for `octocat` with 6 repos, 6 languages (percentages sum to 100%), and contribution stats
- **`src/data/github.ts`** — `fetchGitHubUser(username)` using `@octokit/rest`; fetches profile + top repos + language breakdown (top 6 repos aggregated), heuristic contribution stats
- **`src/data/index.ts`** — `getDevCardData(username)`: calls `fetchGitHubUser`, falls back to fixture for `"octocat"` on any error, throws for other usernames
- **`src/data/__tests__/github.test.ts`** — Unit tests covering fixture fallback and fixture shape validation

### Test Results

```
Test Files  2 passed (2)
     Tests  4 passed (4)
```

### Build

`npm run build` succeeds with no TypeScript errors.

---

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22424513423)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22424513423, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22424513423 -->

<!-- gh-aw-workflow-id: repo-assist -->