### PR TITLE
[Pipeline] Card Component — Profile Section (Avatar, Bio, Stats)

### DIFF
--- a/src/components/card/__tests__/dev-card.test.tsx
+++ b/src/components/card/__tests__/dev-card.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DevCard from "../dev-card";
+import sampleUser from "@/data/fixtures/sample-user.json";
+import type { DevCardData } from "@/data/types";
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+}));
+
+const fixtureData = sampleUser as DevCardData;
+
+describe("DevCard", () => {
+  it("renders avatar img with correct alt text", () => {
+    render(<DevCard data={fixtureData} />);
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("alt", "The Octocat's avatar");
+  });
+
+  it("renders display name and @login", () => {
+    render(<DevCard data={fixtureData} />);
+    expect(screen.getByText("The Octocat")).toBeInTheDocument();
+    expect(screen.getByText("@octocat")).toBeInTheDocument();
+  });
+
+  it("renders stats row with correct repo/follower counts", () => {
+    render(<DevCard data={fixtureData} />);
+    expect(screen.getByText("8 repos")).toBeInTheDocument();
+    expect(screen.getByText("15000 followers")).toBeInTheDocument();
+    expect(screen.getByText("9 following")).toBeInTheDocument();
+  });
+
+  it("does not render bio element when bio is null", () => {
+    const noBio: DevCardData = {
+      ...fixtureData,
+      user: { ...fixtureData.user, bio: null },
+    };
+    render(<DevCard data={noBio} />);
+    expect(screen.queryByText("A mysterious entity that loves Git.")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/card/dev-card.tsx
+++ b/src/components/card/dev-card.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Image from "next/image";
+import { motion } from "framer-motion";
+import type { DevCardData } from "@/data/types";
+
+interface DevCardProps {
+  data: DevCardData;
+  theme?: string;
+}
+
+export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
+  const { user } = data;
+
+  return (
+    <div
+      data-card-root
+      style={{
+        width: 400,
+        height: 560,
+        background: "linear-gradient(135deg, #0f172a, #1e293b)",
+        borderRadius: "1rem",
+        overflow: "hidden",
+        color: "#ffffff",
+        display: "flex",
+        flexDirection: "column",
+        padding: "1.5rem",
+        boxSizing: "border-box",
+      }}
+    >
+      {/* Profile Section */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0 }}
+        style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "0.5rem" }}
+      >
+        <Image
+          src={user.avatarUrl}
+          alt={`${user.name ?? user.login}'s avatar`}
+          width={96}
+          height={96}
+          style={{
+            borderRadius: "50%",
+            border: "2px solid #3b82f6",
+          }}
+        />
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontWeight: "bold", fontSize: "1.25rem" }}>{user.name ?? user.login}</div>
+          <div style={{ color: "#94a3b8", fontSize: "0.875rem" }}>@{user.login}</div>
+        </div>
+
+        {user.bio && (
+          <div
+            style={{
+              color: "#cbd5e1",
+              fontSize: "0.875rem",
+              textAlign: "center",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {user.bio}
+          </div>
+        )}
+
+        {(user.location || user.company) && (
+          <div style={{ display: "flex", gap: "1rem", fontSize: "0.75rem", color: "#94a3b8" }}>
+            {user.location && <span>📍 {user.location}</span>}
+            {user.company && <span>🏢 {user.company}</span>}
+          </div>
+        )}
+
+        {/* Stats Row */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.1 }}
+          style={{ display: "flex", gap: "0.5rem", fontSize: "0.75rem", color: "#94a3b8" }}
+        >
+          <span>{user.publicRepos} repos</span>
+          <span>|</span>
+          <span>{user.followers} followers</span>
+          <span>|</span>
+          <span>{user.following} following</span>
+        </motion.div>
+      </motion.div>
+
+      {/* Language Bar Placeholder */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.2 }}
+        style={{ marginTop: "1rem" }}
+      />
+
+      {/* Top Repos Placeholder */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.3 }}
+        style={{ marginTop: "1rem" }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #66

## Summary

Implements the core DevCard wrapper component and profile section displaying the user's avatar, name, bio, location, company, and stats.

### Files Added

- **`src/components/card/dev-card.tsx`** — Main card wrapper (400×560px fixed size):
  - Props: `data: DevCardData`, `theme?: string`
  - `data-card-root` attribute for PNG export targeting
  - Circular avatar via `next/image` with `alt="{name}'s avatar"`
  - Display name (bold), `@login` in muted text
  - Bio (2-line clamp), hidden when `null`
  - Location (📍) and company (🏢) row, each hidden when `null`
  - Stats row: repos | followers | following
  - Framer Motion stagger animation (y:20, 0.1s delay between sections)

- **`src/components/card/__tests__/dev-card.test.tsx`** — 4 tests:
  - Avatar renders with correct `alt` text
  - Name and `@login` render correctly
  - Stats row shows correct counts
  - Bio element absent when `bio` is `null`

### Test Results

```
✓ src/components/card/__tests__/dev-card.test.tsx (4 tests)
Tests: 8 passed (8)
```

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22426418796)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22426418796, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22426418796 -->

<!-- gh-aw-workflow-id: repo-assist -->