### PR TITLE
[Pipeline] OG Image API Route — Social Media Preview Image Generation

### DIFF
--- a/src/app/api/og/[username]/route.tsx
+++ b/src/app/api/og/[username]/route.tsx
@@ -1,0 +1,119 @@
+import { ImageResponse } from "@vercel/og";
+import { NextResponse } from "next/server";
+import { getDevCardData } from "@/data";
+
+export const runtime = "edge";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { username: string } }
+) {
+  const { username } = params;
+
+  let data;
+  try {
+    data = await getDevCardData(username);
+  } catch {
+    return new NextResponse("User not found", { status: 404 });
+  }
+
+  const { user, languages } = data;
+  const topLangs = languages.slice(0, 3);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "#0f172a",
+          padding: "48px",
+          fontFamily: "sans-serif",
+          color: "white",
+          justifyContent: "space-between",
+        }}
+      >
+        {/* Top: avatar + user info + languages */}
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          {/* Left: avatar + name */}
+          <div style={{ display: "flex", alignItems: "flex-start", gap: "24px" }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={user.avatarUrl}
+              width={128}
+              height={128}
+              style={{ borderRadius: "50%", objectFit: "cover" }}
+              alt=""
+            />
+            <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+              <span style={{ fontSize: "32px", fontWeight: "bold", color: "white" }}>
+                {user.name ?? user.login}
+              </span>
+              <span style={{ fontSize: "20px", color: "#94a3b8" }}>@{user.login}</span>
+              {user.bio && (
+                <span
+                  style={{
+                    fontSize: "16px",
+                    color: "#94a3b8",
+                    maxWidth: "400px",
+                    overflow: "hidden",
+                    display: "-webkit-box",
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical",
+                  }}
+                >
+                  {user.bio}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Right: top 3 languages */}
+          <div style={{ display: "flex", flexDirection: "column", gap: "12px", alignItems: "flex-end" }}>
+            {topLangs.map((lang) => (
+              <div key={lang.name} style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                <div
+                  style={{
+                    width: "12px",
+                    height: "12px",
+                    borderRadius: "50%",
+                    backgroundColor: lang.color,
+                  }}
+                />
+                <span style={{ fontSize: "18px", color: "#e2e8f0" }}>{lang.name}</span>
+                <span style={{ fontSize: "16px", color: "#64748b" }}>{lang.percentage}%</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Bottom: language bar + watermark */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          <div style={{ display: "flex", height: "8px", borderRadius: "4px", overflow: "hidden" }}>
+            {languages.map((lang) => (
+              <div
+                key={lang.name}
+                style={{
+                  flex: `0 0 ${lang.percentage}%`,
+                  backgroundColor: lang.color,
+                }}
+              />
+            ))}
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <span style={{ fontSize: "14px", color: "#475569" }}>DevCard</span>
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      headers: {
+        "Cache-Control": "public, max-age=86400, s-maxage=86400",
+      },
+    }
+  );
+}

--- a/src/app/api/og/__tests__/og.test.ts
+++ b/src/app/api/og/__tests__/og.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import fixture from "@/data/fixtures/sample-user.json";
+import type { DevCardData } from "@/data/types";
+
+// Mock @vercel/og before importing the route
+vi.mock("@vercel/og", () => ({
+  ImageResponse: class MockImageResponse extends Response {
+    constructor(_jsx: unknown, init?: ResponseInit & { headers?: Record<string, string> }) {
+      super(new Uint8Array([137, 80, 78, 71]), {
+        ...init,
+        headers: {
+          "Content-Type": "image/png",
+          ...(init?.headers ?? {}),
+        },
+      });
+    }
+  },
+}));
+
+vi.mock("@/data", () => ({
+  getDevCardData: vi.fn().mockResolvedValue(fixture as DevCardData),
+}));
+
+describe("OG Image Route", () => {
+  it("GET /api/og/octocat returns image/png response", async () => {
+    const { GET } = await import("../[username]/route.tsx");
+    const req = new Request("http://localhost/api/og/octocat");
+    const res = await GET(req, { params: { username: "octocat" } });
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+  });
+
+  it("GET /api/og/unknown returns 404 when data fetch fails", async () => {
+    const { getDevCardData } = await import("@/data");
+    vi.mocked(getDevCardData).mockRejectedValueOnce(new Error("not found"));
+    const { GET } = await import("../[username]/route.tsx");
+    const req = new Request("http://localhost/api/og/unknown");
+    const res = await GET(req, { params: { username: "unknown" } });
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe("User not found");
+  });
+});


### PR DESCRIPTION
Closes #72

## Summary

Implements the OG Image API route that generates 1200×630 Open Graph images for social media previews when DevCard URLs are shared.

### Files Added

- **`src/app/api/og/[username]/route.tsx`** — Next.js Route Handler with `runtime = "edge"`:
  - Fetches `DevCardData` via `getDevCardData(username)`, falls back to 404 on failure
  - Returns `ImageResponse` (from `@vercel/og`) at 1200×630px with:
    - Dark `"midnight"` background (`#0f172a`)
    - Left: circular avatar (128px), name (bold/32px), login (muted/20px), bio (2-line clamp)
    - Right: top 3 languages with colored dots + percentages
    - Bottom: proportional language bar using flex divs + "DevCard" watermark
  - Sets `Cache-Control: public, max-age=86400, s-maxage=86400`
  - Returns 404 + "User not found" if fetch fails

- **`src/app/api/og/__tests__/og.test.ts`** — Tests:
  - GET `/api/og/octocat` returns `Content-Type: image/png`
  - GET `/api/og/unknown` returns 404 when data fetch fails

> **Note**: The `generateMetadata` update to `src/app/card/[username]/page.tsx` (to add `openGraph.images`) will be applied when issue #70 creates that file.

### Test Results

All tests pass:
```
✓ src/app/api/og/__tests__/og.test.ts  (2 tests)
✓ src/app/__tests__/page.test.tsx  (1 test)
✓ src/data/__tests__/github.test.ts  (3 tests)
Test Files  3 passed (3)
Tests  6 passed (6)
```

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22426685507)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22426685507, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22426685507 -->

<!-- gh-aw-workflow-id: repo-assist -->