### PR TITLE
[Pipeline] Card Themes — Theme Data, DevCard Theming, and Theme Selector

### DIFF
--- a/src/components/card/__tests__/themes.test.tsx
+++ b/src/components/card/__tests__/themes.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DevCard from "../dev-card";
+import ThemeSelector from "../theme-selector";
+import { THEMES } from "@/data/themes";
+import sampleUser from "@/data/fixtures/sample-user.json";
+import type { DevCardData } from "@/data/types";
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+}));
+
+const fixtureData = sampleUser as DevCardData;
+
+describe("ThemeSelector", () => {
+  it("renders all 6 theme swatches", () => {
+    const onChange = vi.fn();
+    render(<ThemeSelector currentTheme="midnight" onChange={onChange} />);
+    THEMES.forEach((theme) => {
+      expect(screen.getByRole("button", { name: `Select ${theme.name} theme` })).toBeInTheDocument();
+    });
+  });
+
+  it("calls onChange with the correct themeId when a swatch is clicked", () => {
+    const onChange = vi.fn();
+    render(<ThemeSelector currentTheme="midnight" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "Select Neon theme" }));
+    expect(onChange).toHaveBeenCalledWith("neon");
+  });
+});
+
+describe("DevCard theming", () => {
+  it("applies neon accent color when theme is 'neon'", () => {
+    render(<DevCard data={fixtureData} theme="neon" />);
+    const card = document.querySelector("[data-card-root]") as HTMLElement;
+    expect(card).toBeTruthy();
+    expect(card.style.background).toMatch(/^(#000000|rgb\(0,\s*0,\s*0\))$/);
+    expect(card.style.boxShadow).toBe("0 0 0 1px #ec4899, 0 0 20px #ec4899");
+  });
+
+  it("uses midnight theme by default", () => {
+    render(<DevCard data={fixtureData} />);
+    const card = document.querySelector("[data-card-root]") as HTMLElement;
+    expect(card.style.background).toContain("0f172a");
+  });
+});

--- a/src/components/card/dev-card.tsx
+++ b/src/components/card/dev-card.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { motion } from "framer-motion";
 import type { DevCardData } from "@/data/types";
+import { THEMES } from "@/data/themes";
 
 interface DevCardProps {
   data: DevCardData;
@@ -11,6 +12,8 @@ interface DevCardProps {
 
 export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
   const { user } = data;
+  const activeTheme = THEMES.find((t) => t.id === theme) ?? THEMES[0];
+  const isNeon = activeTheme.id === "neon";
 
   return (
     <div
@@ -18,14 +21,15 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
       style={{
         width: 400,
         height: 560,
-        background: "linear-gradient(135deg, #0f172a, #1e293b)",
+        background: activeTheme.background,
         borderRadius: "1rem",
         overflow: "hidden",
-        color: "#ffffff",
+        color: activeTheme.textPrimary,
         display: "flex",
         flexDirection: "column",
         padding: "1.5rem",
         boxSizing: "border-box",
+        ...(isNeon ? { boxShadow: activeTheme.borderColor } : {}),
       }}
     >
       {/* Profile Section */}
@@ -42,18 +46,22 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
           height={96}
           style={{
             borderRadius: "50%",
-            border: "2px solid #3b82f6",
+            border: isNeon ? "1px solid " + activeTheme.accentColor : activeTheme.borderColor,
           }}
         />
         <div style={{ textAlign: "center" }}>
-          <div style={{ fontWeight: "bold", fontSize: "1.25rem" }}>{user.name ?? user.login}</div>
-          <div style={{ color: "#94a3b8", fontSize: "0.875rem" }}>@{user.login}</div>
+          <div style={{ fontWeight: "bold", fontSize: "1.25rem", color: activeTheme.textPrimary }}>
+            {user.name ?? user.login}
+          </div>
+          <div style={{ color: activeTheme.textSecondary, fontSize: "0.875rem" }}>
+            @{user.login}
+          </div>
         </div>
 
         {user.bio && (
           <div
             style={{
-              color: "#cbd5e1",
+              color: activeTheme.textSecondary,
               fontSize: "0.875rem",
               textAlign: "center",
               display: "-webkit-box",
@@ -67,7 +75,14 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
         )}
 
         {(user.location || user.company) && (
-          <div style={{ display: "flex", gap: "1rem", fontSize: "0.75rem", color: "#94a3b8" }}>
+          <div
+            style={{
+              display: "flex",
+              gap: "1rem",
+              fontSize: "0.75rem",
+              color: activeTheme.textSecondary,
+            }}
+          >
             {user.location && <span>📍 {user.location}</span>}
             {user.company && <span>🏢 {user.company}</span>}
           </div>
@@ -78,12 +93,17 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4, delay: 0.1 }}
-          style={{ display: "flex", gap: "0.5rem", fontSize: "0.75rem", color: "#94a3b8" }}
+          style={{
+            display: "flex",
+            gap: "0.5rem",
+            fontSize: "0.75rem",
+            color: activeTheme.accentColor,
+          }}
         >
           <span>{user.publicRepos} repos</span>
-          <span>|</span>
+          <span style={{ color: activeTheme.textSecondary }}>|</span>
           <span>{user.followers} followers</span>
-          <span>|</span>
+          <span style={{ color: activeTheme.textSecondary }}>|</span>
           <span>{user.following} following</span>
         </motion.div>
       </motion.div>

--- a/src/components/card/theme-selector.tsx
+++ b/src/components/card/theme-selector.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { THEMES } from "@/data/themes";
+
+interface ThemeSelectorProps {
+  currentTheme: string;
+  onChange: (themeId: string) => void;
+}
+
+export default function ThemeSelector({ currentTheme, onChange }: ThemeSelectorProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: "0.5rem",
+        justifyContent: "center",
+        alignItems: "center",
+        padding: "0.5rem",
+      }}
+    >
+      {THEMES.map((theme) => {
+        const isActive = theme.id === currentTheme;
+        return (
+          <button
+            key={theme.id}
+            onClick={() => onChange(theme.id)}
+            aria-label={`Select ${theme.name} theme`}
+            style={{
+              position: "relative",
+              width: 24,
+              height: 24,
+              borderRadius: "50%",
+              background: theme.background,
+              border: "none",
+              cursor: "pointer",
+              padding: 0,
+              flexShrink: 0,
+            }}
+          >
+            {isActive && (
+              <motion.span
+                layoutId="theme-ring"
+                style={{
+                  position: "absolute",
+                  inset: -3,
+                  borderRadius: "50%",
+                  border: "2px solid #ffffff",
+                  pointerEvents: "none",
+                }}
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/data/themes.ts
+++ b/src/data/themes.ts
@@ -1,0 +1,66 @@
+export interface Theme {
+  id: string;
+  name: string;
+  background: string;
+  textPrimary: string;
+  textSecondary: string;
+  accentColor: string;
+  borderColor: string;
+}
+
+export const THEMES: Theme[] = [
+  {
+    id: "midnight",
+    name: "Midnight",
+    background: "linear-gradient(135deg, #0f172a, #1e293b)",
+    textPrimary: "#ffffff",
+    textSecondary: "#94a3b8",
+    accentColor: "#3b82f6",
+    borderColor: "2px solid #3b82f6",
+  },
+  {
+    id: "aurora",
+    name: "Aurora",
+    background: "linear-gradient(135deg, #064e3b, #312e81)",
+    textPrimary: "#ffffff",
+    textSecondary: "#a7f3d0",
+    accentColor: "#10b981",
+    borderColor: "2px solid #10b981",
+  },
+  {
+    id: "sunset",
+    name: "Sunset",
+    background: "linear-gradient(135deg, #1c1917, #431407)",
+    textPrimary: "#fef3c7",
+    textSecondary: "#fcd34d",
+    accentColor: "#f97316",
+    borderColor: "2px solid #f97316",
+  },
+  {
+    id: "neon",
+    name: "Neon",
+    background: "#000000",
+    textPrimary: "#ffffff",
+    textSecondary: "#f9a8d4",
+    accentColor: "#ec4899",
+    borderColor: "0 0 0 1px #ec4899, 0 0 20px #ec4899",
+  },
+  {
+    id: "arctic",
+    name: "Arctic",
+    background: "linear-gradient(135deg, #f8fafc, #e2e8f0)",
+    textPrimary: "#0f172a",
+    textSecondary: "#475569",
+    accentColor: "#0ea5e9",
+    borderColor: "2px solid #0ea5e9",
+  },
+  {
+    id: "mono",
+    name: "Mono",
+    background: "#18181b",
+    textPrimary: "#ffffff",
+    textSecondary: "#a1a1aa",
+    accentColor: "#ffffff",
+    borderColor: "2px solid #ffffff",
+  },
+];


### PR DESCRIPTION
Closes #69

## Summary

Implements the 6 card themes, wires them into the `DevCard` component, and adds the `ThemeSelector` swatch row.

### Files Added / Modified

- **`src/data/themes.ts`** — `THEMES: Theme[]` with 6 themes: `midnight` (default), `aurora`, `sunset`, `neon`, `arctic`, `mono`. Exports `Theme` interface.
- **`src/components/card/dev-card.tsx`** — Updated to resolve the active theme via `THEMES.find(t => t.id === theme) ?? THEMES[0]` and apply `background`, `textPrimary`, `textSecondary`, `accentColor` as inline styles. Neon theme applies `boxShadow` glow to card root.
- **`src/components/card/theme-selector.tsx`** — Row of 6 circular 24px swatches, each showing its gradient background. Active theme has a `ring-2`-style Framer Motion `layoutId="theme-ring"` indicator.
- **`src/components/card/__tests__/themes.test.tsx`** — 4 tests: all 6 swatches render, onChange fires with correct id, neon card has black background + glow boxShadow, midnight is the default.

### Test Results

```
Test Files  6 passed (6)
      Tests  19 passed (19)
```

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22426863829)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22426863829, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22426863829 -->

<!-- gh-aw-workflow-id: repo-assist -->