### PR TITLE
[Pipeline] Card Generator Page — /card/[username] Dynamic Route

### DIFF
--- a/src/app/card/[username]/card-view.tsx
+++ b/src/app/card/[username]/card-view.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import DevCard from "@/components/card/dev-card";
+import ThemeSelector from "@/components/card/theme-selector";
+import type { DevCardData } from "@/data/types";
+
+interface CardViewProps {
+  data: DevCardData;
+  username: string;
+}
+
+export default function CardView({ data, username }: CardViewProps) {
+  const [theme, setTheme] = useState("midnight");
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      className="flex flex-col items-center gap-4"
+    >
+      <DevCard data={data} theme={theme} />
+      <ThemeSelector currentTheme={theme} onChange={setTheme} />
+      <div className="text-center mt-2">
+        <p className="text-gray-400 text-sm mb-1">Share this card</p>
+        <input
+          type="text"
+          readOnly
+          value={typeof window !== "undefined" ? window.location.href : `/card/${username}`}
+          className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-300 w-72 text-center outline-none"
+        />
+      </div>
+      {/* Export controls placeholder */}
+      <div className="text-gray-500 text-sm">Export controls coming soon</div>
+    </motion.div>
+  );
+}

--- a/src/app/card/[username]/loading.tsx
+++ b/src/app/card/[username]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-gray-950 to-gray-900 flex flex-col items-center justify-center px-4">
+      <div className="w-[400px] h-[560px] rounded-2xl bg-gray-800 animate-pulse" />
+    </main>
+  );
+}

--- a/src/app/card/[username]/page.tsx
+++ b/src/app/card/[username]/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { getDevCardData } from "@/data";
+import CardView from "./card-view";
+
+interface Props {
+  params: { username: string };
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { username } = params;
+  return {
+    title: `DevCard — @${username}`,
+    description: `Developer identity card for @${username}`,
+    openGraph: {
+      images: [`/api/og/${username}`],
+    },
+  };
+}
+
+export default async function CardPage({ params }: Props) {
+  const { username } = params;
+
+  let data;
+  try {
+    data = await getDevCardData(username);
+  } catch {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-gray-950 to-gray-900 text-white">
+      <div className="max-w-md mx-auto px-4 py-12 flex flex-col items-center gap-6">
+        <CardView data={data} username={username} />
+        <Link
+          href="/"
+          className="text-indigo-400 hover:text-indigo-300 text-sm font-medium"
+        >
+          ← Generate Another
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/card/__tests__/page.test.tsx
+++ b/src/app/card/__tests__/page.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import fixture from "@/data/fixtures/sample-user.json";
+import type { DevCardData } from "@/data/types";
+
+// Mock getDevCardData
+vi.mock("@/data", () => ({
+  getDevCardData: vi.fn(),
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+// Mock framer-motion
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, tag: string) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ({ children, ...props }: any) =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (React as any).createElement(tag, props, children),
+    }
+  ),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  layoutId: undefined,
+}));
+
+import { getDevCardData } from "@/data";
+import CardPage from "../[username]/page";
+
+const mockGetDevCardData = vi.mocked(getDevCardData);
+
+describe("CardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the DevCard for fixture data", async () => {
+    mockGetDevCardData.mockResolvedValue(fixture as DevCardData);
+
+    const element = await CardPage({ params: { username: "octocat" } });
+    render(element);
+
+    expect(screen.getAllByText(/octocat/i).length).toBeGreaterThan(0);
+  });
+
+  it("calls notFound when getDevCardData throws a 404-like error", async () => {
+    mockGetDevCardData.mockRejectedValue(new Error("Not found"));
+
+    const { notFound } = await import("next/navigation");
+
+    await expect(CardPage({ params: { username: "nonexistentuser99999" } })).rejects.toThrow(
+      "NEXT_NOT_FOUND"
+    );
+    expect(notFound).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #70

## Changes

Implements the `/card/[username]` dynamic route as specified in issue #70.

### Files Added
- `src/app/card/[username]/page.tsx` — Server component with `generateMetadata` (title, description, OG image), fetches `DevCardData` server-side, calls `notFound()` on errors
- `src/app/card/[username]/card-view.tsx` — Client component managing `theme` state, renders `DevCard` + `ThemeSelector`, share URL input, and export placeholder
- `src/app/card/[username]/loading.tsx` — Card-sized skeleton (`w-[400px] h-[560px]`) with `animate-pulse`
- `src/app/card/__tests__/page.test.tsx` — 2 tests: fixture render + 404 handling

### Test Results
```
✓ src/app/card/__tests__/page.test.tsx  (2 tests)
Tests: 25 passed (25) — all passing
```

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22427183793)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22427183793, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22427183793 -->

<!-- gh-aw-workflow-id: repo-assist -->