### PR TITLE
[Pipeline] Gallery Page — Grid of Notable Developer DevCards

### DIFF
--- a/src/app/gallery/__tests__/gallery.test.tsx
+++ b/src/app/gallery/__tests__/gallery.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import fixture from "@/data/fixtures/sample-user.json";
+import type { DevCardData } from "@/data/types";
+
+vi.mock("@/data", () => ({
+  getDevCardData: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, tag: string) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ({ children, ...props }: any) =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (React as any).createElement(tag, props, children),
+    }
+  ),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { getDevCardData } from "@/data";
+import GalleryPage from "../page";
+
+const mockGetDevCardData = vi.mocked(getDevCardData);
+
+describe("GalleryPage", () => {
+  it("renders the Gallery heading", async () => {
+    mockGetDevCardData.mockResolvedValue(fixture as DevCardData);
+
+    const element = await GalleryPage();
+    render(element);
+
+    expect(screen.getByText("Gallery")).toBeTruthy();
+  });
+
+  it("renders at least one card when fixture data is used", async () => {
+    mockGetDevCardData.mockResolvedValue(fixture as DevCardData);
+
+    const element = await GalleryPage();
+    render(element);
+
+    // Should have octocat tagline visible
+    expect(screen.getByText("GitHub's mascot")).toBeTruthy();
+  });
+});

--- a/src/app/gallery/gallery-grid.tsx
+++ b/src/app/gallery/gallery-grid.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import DevCard from "@/components/card/dev-card";
+import type { DevCardData } from "@/data/types";
+import type { GalleryUser } from "@/data/gallery-users";
+
+interface GalleryCardItem {
+  user: GalleryUser;
+  data: DevCardData;
+}
+
+interface GalleryGridProps {
+  cards: GalleryCardItem[];
+}
+
+export default function GalleryGrid({ cards }: GalleryGridProps) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
+      {cards.map(({ user, data }, i) => (
+        <motion.div
+          key={user.username}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: i * 0.05 }}
+        >
+          <Link href={`/card/${user.username}`} className="block">
+            <div style={{ height: 400, overflow: "hidden", position: "relative" }}>
+              <div style={{ transform: "scale(0.75)", transformOrigin: "top center" }}>
+                <DevCard data={data} theme="midnight" />
+              </div>
+            </div>
+          </Link>
+          <p className="text-sm text-gray-400 text-center mt-2">{user.tagline}</p>
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { getDevCardData } from "@/data";
+import { GALLERY_USERS } from "@/data/gallery-users";
+import GalleryGrid from "./gallery-grid";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Gallery — DevCard",
+  description: "DevCards for notable developers",
+};
+
+export default async function GalleryPage() {
+  const results = await Promise.allSettled(
+    GALLERY_USERS.map((u) => getDevCardData(u.username))
+  );
+
+  const cards = GALLERY_USERS.map((user, i) => {
+    const result = results[i];
+    if (result.status === "fulfilled") {
+      return { user, data: result.value };
+    }
+    return null;
+  }).filter(Boolean) as { user: (typeof GALLERY_USERS)[0]; data: Awaited<ReturnType<typeof getDevCardData>> }[];
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-gray-950 to-gray-900 text-white px-6 py-12">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-3xl font-bold mb-2">Gallery</h1>
+        <p className="text-gray-400 mb-10">Cards generated for notable developers</p>
+        <GalleryGrid cards={cards} />
+        <div className="mt-12 text-center">
+          <Link href="/" className="text-indigo-400 hover:text-indigo-300 text-sm font-medium">
+            ← Generate your own card
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/data/gallery-users.ts
+++ b/src/data/gallery-users.ts
@@ -1,0 +1,15 @@
+export interface GalleryUser {
+  username: string;
+  tagline: string;
+}
+
+export const GALLERY_USERS: GalleryUser[] = [
+  { username: "torvalds", tagline: "Creator of Linux and Git" },
+  { username: "gaearon", tagline: "Co-creator of React and Redux" },
+  { username: "sindresorhus", tagline: "Prolific open-source maintainer" },
+  { username: "addyosmani", tagline: "Engineering manager at Google Chrome" },
+  { username: "kentcdodds", tagline: "Creator of Testing Library" },
+  { username: "sarah-edo", tagline: "Core Vue.js team member" },
+  { username: "ThePrimeagen", tagline: "Developer educator and Neovim advocate" },
+  { username: "octocat", tagline: "GitHub's mascot" },
+];


### PR DESCRIPTION
Closes #73

## Changes

Implements the `/gallery` page as specified in issue #73.

### Files Added
- `src/data/gallery-users.ts` — `GALLERY_USERS` array with 8 notable developers + `GalleryUser` interface
- `src/app/gallery/page.tsx` — Server component, `Promise.allSettled` for all 8 users, page metadata, `revalidate = 3600`
- `src/app/gallery/gallery-grid.tsx` — Client component with Framer Motion stagger animation (0.05s/card), 75% scaled DevCards in fixed-height wrappers, links to `/card/[username]`
- `src/app/gallery/__tests__/gallery.test.tsx` — 2 tests: Gallery heading + card rendering with fixture

### Test Results
```
✓ src/app/gallery/__tests__/gallery.test.tsx  (2 tests)
Tests: 25 passed (25) — all passing
```

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22427183793)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22427183793, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22427183793 -->

<!-- gh-aw-workflow-id: repo-assist -->