### PR TITLE
[Pipeline] Card Export — Download PNG and Copy Link Buttons

### DIFF
--- a/src/app/card/[username]/card-view.tsx
+++ b/src/app/card/[username]/card-view.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 import DevCard from "@/components/card/dev-card";
 import ThemeSelector from "@/components/card/theme-selector";
+import ExportButton from "@/components/card/export-button";
+import { THEMES } from "@/data/themes";
 import type { DevCardData } from "@/data/types";
 
 interface CardViewProps {
@@ -13,6 +15,7 @@ interface CardViewProps {
 
 export default function CardView({ data, username }: CardViewProps) {
   const [theme, setTheme] = useState("midnight");
+  const currentTheme = THEMES.find((t) => t.id === theme) ?? THEMES[0];
 
   return (
     <motion.div
@@ -23,6 +26,7 @@ export default function CardView({ data, username }: CardViewProps) {
     >
       <DevCard data={data} theme={theme} />
       <ThemeSelector currentTheme={theme} onChange={setTheme} />
+      <ExportButton username={username} accentColor={currentTheme.accentColor} />
       <div className="text-center mt-2">
         <p className="text-gray-400 text-sm mb-1">Share this card</p>
         <input
@@ -32,8 +36,6 @@ export default function CardView({ data, username }: CardViewProps) {
           className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-300 w-72 text-center outline-none"
         />
       </div>
-      {/* Export controls placeholder */}
-      <div className="text-gray-500 text-sm">Export controls coming soon</div>
     </motion.div>
   );
 }

--- a/src/components/card/__tests__/export-button.test.tsx
+++ b/src/components/card/__tests__/export-button.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ExportButton from "../export-button";
+
+vi.mock("html-to-image", () => ({
+  toPng: vi.fn().mockResolvedValue("data:image/png;base64,abc"),
+}));
+
+describe("ExportButton", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    // Provide a mock card root element
+    const div = document.createElement("div");
+    div.setAttribute("data-card-root", "true");
+    document.body.appendChild(div);
+  });
+
+  it("renders Download PNG and Copy Link buttons", () => {
+    render(<ExportButton username="octocat" accentColor="#6366f1" />);
+    expect(screen.getByText("Download PNG")).toBeDefined();
+    expect(screen.getByText("Copy Link")).toBeDefined();
+  });
+
+  it("Copy Link calls navigator.clipboard.writeText with current URL", async () => {
+    render(<ExportButton username="octocat" accentColor="#6366f1" />);
+    const btn = screen.getByText("Copy Link");
+    fireEvent.click(btn);
+    await vi.waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        window.location.href
+      );
+    });
+  });
+});

--- a/src/components/card/export-button.tsx
+++ b/src/components/card/export-button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { exportCardAsPng } from "@/lib/export";
+
+interface ExportButtonProps {
+  username: string;
+  accentColor: string;
+}
+
+export default function ExportButton({ username, accentColor }: ExportButtonProps) {
+  const [downloading, setDownloading] = useState(false);
+  const [downloaded, setDownloaded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function handleDownload() {
+    const el = document.querySelector("[data-card-root]") as HTMLElement | null;
+    if (!el) return;
+    setDownloading(true);
+    try {
+      await exportCardAsPng(el, username);
+      setDownloaded(true);
+      setTimeout(() => setDownloaded(false), 2000);
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  async function handleCopyLink() {
+    await navigator.clipboard.writeText(window.location.href);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  const downloadLabel = downloading ? "Downloading..." : downloaded ? "✓ Downloaded" : "Download PNG";
+
+  return (
+    <div className="flex gap-3">
+      <button
+        onClick={handleDownload}
+        disabled={downloading}
+        style={{ backgroundColor: accentColor }}
+        className="px-4 py-2 rounded-lg text-white text-sm font-medium disabled:opacity-60 transition-opacity"
+      >
+        {downloadLabel}
+      </button>
+      <button
+        onClick={handleCopyLink}
+        className="px-4 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 text-white text-sm font-medium transition-colors"
+      >
+        {copied ? "Copied!" : "Copy Link"}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,20 @@
+import { toPng } from "html-to-image";
+
+export async function exportCardAsPng(
+  element: HTMLElement,
+  username: string
+): Promise<void> {
+  const dataUrl = await toPng(element, {
+    width: 800,
+    height: 1120,
+    pixelRatio: 2,
+    fetchRequestInit: { mode: "cors" },
+  });
+
+  const a = document.createElement("a");
+  a.href = dataUrl;
+  a.download = `devcard-${username}.png`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}


### PR DESCRIPTION
Closes #71

## Changes

- **`src/lib/export.ts`** — `exportCardAsPng(element, username)` using `html-to-image`'s `toPng` at 800×1120 `@2x` with CORS fetch mode
- **`src/components/card/export-button.tsx`** — `"use client"` component with two buttons:
  - **Download PNG**: calls `exportCardAsPng([data-card-root])`, shows `"Downloading…"` while active and `"✓ Downloaded"` for 2s after success; styled with theme `accentColor`
  - **Copy Link**: copies `window.location.href` via `navigator.clipboard`, shows `"Copied!"` for 2s
- **`src/components/card/__tests__/export-button.test.tsx`** — Tests: renders both buttons, Copy Link calls `navigator.clipboard.writeText` with correct URL
- **`src/app/card/[username]/card-view.tsx`** — Import `ExportButton` + `THEMES`, resolve `accentColor` from current theme, render `(ExportButton)` in place of the old placeholder

## Test Results

```
Test Files  11 passed (11)
      Tests  29 passed (29)
```

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22427480512)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22427480512, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22427480512 -->

<!-- gh-aw-workflow-id: repo-assist -->