### PR TITLE
[Pipeline] fix: wire LanguageBar and TopRepos into DevCard component

### DIFF
--- a/src/components/card/dev-card.tsx
+++ b/src/components/card/dev-card.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import type { DevCardData } from "@/data/types";
 import { THEMES } from "@/data/themes";
+import LanguageBar from "@/components/card/language-bar";
+import TopRepos from "@/components/card/top-repos";
 
 interface DevCardProps {
   data: DevCardData;
@@ -11,7 +13,7 @@ interface DevCardProps {
 }
 
 export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
-  const { user } = data;
+  const { user, languages, topRepos } = data;
   const activeTheme = THEMES.find((t) => t.id === theme) ?? THEMES[0];
   const isNeon = activeTheme.id === "neon";
 
@@ -108,21 +110,25 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
         </motion.div>
       </motion.div>
 
-      {/* Language Bar Placeholder */}
+      {/* Language Bar */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.2 }}
         style={{ marginTop: "1rem" }}
-      />
+      >
+        <LanguageBar languages={languages} />
+      </motion.div>
 
-      {/* Top Repos Placeholder */}
+      {/* Top Repos */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.3 }}
         style={{ marginTop: "1rem" }}
-      />
+      >
+        <TopRepos repos={topRepos} />
+      </motion.div>
     </div>
   );
 }


### PR DESCRIPTION
Fixes the DevCard component which was rendering empty placeholder divs where the language breakdown and top repos sections should appear.

## Changes

- Import `LanguageBar` and `TopRepos` components in `dev-card.tsx`
- Destructure `languages` and `topRepos` from `data` prop
- Replace `{/* Language Bar Placeholder */}` motion.div with `(LanguageBar languages={languages} /)` inside the animation wrapper
- Replace `{/* Top Repos Placeholder */}` motion.div with `(TopRepos repos={topRepos} /)` inside the animation wrapper

## Test Results

All 29 tests pass (`npm test`). Production build succeeds (`npm run build`).

Closes #89

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646575) for issue #89

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22496646575, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646575 -->

<!-- gh-aw-workflow-id: repo-assist -->