### PR TITLE
[Pipeline] fix: update stale sarah-edo username to sdrasner in gallery

### DIFF
--- a/src/data/gallery-users.ts
+++ b/src/data/gallery-users.ts
@@ -9,7 +9,7 @@ export const GALLERY_USERS: GalleryUser[] = [
   { username: "sindresorhus", tagline: "Prolific open-source maintainer" },
   { username: "addyosmani", tagline: "Engineering manager at Google Chrome" },
   { username: "kentcdodds", tagline: "Creator of Testing Library" },
-  { username: "sarah-edo", tagline: "Core Vue.js team member" },
+  { username: "sdrasner", tagline: "Core Vue.js team member" },
   { username: "ThePrimeagen", tagline: "Developer educator and Neovim advocate" },
   { username: "octocat", tagline: "GitHub's mascot" },
 ];


### PR DESCRIPTION
Fixes the 404 error caused by the stale `sarah-edo` GitHub username in the gallery.

## Changes

- In `src/data/gallery-users.ts`, updated `sarah-edo` → `sdrasner` (Sarah Drasner's current GitHub username)
- Tagline unchanged — she is still a Core Vue.js team member

## Test Results

All 29 tests pass (`npm test`).

Closes #90

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646575) for issue #89

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22496646575, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646575 -->

<!-- gh-aw-workflow-id: repo-assist -->