### PR TITLE
[Pipeline] DevCard missing LanguageBar and TopRepos — wire up components

### DIFF
--- a/src/components/card/dev-card.tsx
+++ b/src/components/card/dev-card.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import type { DevCardData } from "@/data/types";
 import { THEMES } from "@/data/themes";
+import LanguageBar from "@/components/card/language-bar";
+import TopRepos from "@/components/card/top-repos";
 
 interface DevCardProps {
   data: DevCardData;
@@ -108,21 +110,25 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
         </motion.div>
       </motion.div>
 
-      {/* Language Bar Placeholder */}
+      {/* Language Bar */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.2 }}
         style={{ marginTop: "1rem" }}
-      />
+      >
+        <LanguageBar languages={data.languages} />
+      </motion.div>
 
-      {/* Top Repos Placeholder */}
+      {/* Top Repos */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.3 }}
         style={{ marginTop: "1rem" }}
-      />
+      >
+        <TopRepos repos={data.topRepos} />
+      </motion.div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #89

## Changes

Wire up the `LanguageBar` and `TopRepos` components inside `DevCard`, replacing the empty placeholder `motion.div` elements that were previously never rendered.

**What changed:**
- Added imports for `LanguageBar` and `TopRepos` in `src/components/card/dev-card.tsx`
- Replaced `{/* Language Bar Placeholder */}` empty `motion.div` with `(LanguageBar languages={data.languages} /)`
- Replaced `{/* Top Repos Placeholder */}` empty `motion.div` with `(TopRepos repos={data.topRepos} /)`
- Preserved the existing `motion.div` animation wrappers (delay 0.2 and 0.3 respectively)

## Test Results

All 29 tests pass. Build succeeds with no TypeScript errors.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646799) for issue #90

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22496646799, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646799 -->

<!-- gh-aw-workflow-id: repo-assist -->