### PR TITLE
[Pipeline] fix(gallery): Replace stale sarah-edo username with sdrasner

### DIFF
--- a/src/data/gallery-users.ts
+++ b/src/data/gallery-users.ts
@@ -9,7 +9,7 @@ export const GALLERY_USERS: GalleryUser[] = [
   { username: "sindresorhus", tagline: "Prolific open-source maintainer" },
   { username: "addyosmani", tagline: "Engineering manager at Google Chrome" },
   { username: "kentcdodds", tagline: "Creator of Testing Library" },
-  { username: "sarah-edo", tagline: "Core Vue.js team member" },
+  { username: "sdrasner", tagline: "Core Vue.js team member" },
   { username: "ThePrimeagen", tagline: "Developer educator and Neovim advocate" },
   { username: "octocat", tagline: "GitHub's mascot" },
 ];


### PR DESCRIPTION
Closes #90

## What changed

Sarah Drasner changed her GitHub username from `sarah-edo` to `sdrasner`. Updated the gallery entry in `src/data/gallery-users.ts` to use her current username so the gallery renders all cards without 404 errors.

## Test results

All 29 tests pass:
```
Test Files  11 passed (11)
     Tests  29 passed (29)
```

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496647635) for issue #91

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22496647635, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496647635 -->

<!-- gh-aw-workflow-id: repo-assist -->