### PR TITLE
[Pipeline] Gallery user sarah-edo returns 404 — update to sdrasner

### DIFF
--- a/src/data/gallery-users.ts
+++ b/src/data/gallery-users.ts
@@ -9,7 +9,7 @@ export const GALLERY_USERS: GalleryUser[] = [
   { username: "sindresorhus", tagline: "Prolific open-source maintainer" },
   { username: "addyosmani", tagline: "Engineering manager at Google Chrome" },
   { username: "kentcdodds", tagline: "Creator of Testing Library" },
-  { username: "sarah-edo", tagline: "Core Vue.js team member" },
+  { username: "sdrasner", tagline: "Core Vue.js team member" },
   { username: "ThePrimeagen", tagline: "Developer educator and Neovim advocate" },
   { username: "octocat", tagline: "GitHub's mascot" },
 ];


### PR DESCRIPTION
Closes #90

## Changes

Updated the stale GitHub username `sarah-edo` to `sdrasner` (Sarah Drasner's current username) in `src/data/gallery-users.ts`.

**What changed:**
- `src/data/gallery-users.ts` line 12: `sarah-edo` → `sdrasner`
- The tagline "Core Vue.js team member" remains unchanged

This resolves the `GET /users/sarah-edo - 404` error in server logs and ensures all 8 gallery cards render successfully.

## Test Results

All 29 tests pass. Build succeeds.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646799) for issue #90

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22496646799, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646799 -->

<!-- gh-aw-workflow-id: repo-assist -->