### PR TITLE
[Pipeline] Add OpenClaw creator steipete to DevCard gallery

### DIFF
--- a/src/data/gallery-users.ts
+++ b/src/data/gallery-users.ts
@@ -12,4 +12,5 @@ export const GALLERY_USERS: GalleryUser[] = [
   { username: "sarah-edo", tagline: "Core Vue.js team member" },
   { username: "ThePrimeagen", tagline: "Developer educator and Neovim advocate" },
   { username: "octocat", tagline: "GitHub's mascot" },
+  { username: "steipete", tagline: "Creator of OpenClaw" },
 ];


### PR DESCRIPTION
Closes #91

## Changes

Added Peter Steinberger (`@steipete`), creator of OpenClaw, to the `GALLERY_USERS` array in `src/data/gallery-users.ts`.

**What changed:**
- `src/data/gallery-users.ts`: Added `{ username: "steipete", tagline: "Creator of OpenClaw" }` as the 9th gallery entry
- No other files changed — the gallery page dynamically maps over `GALLERY_USERS`

The 9th card flows naturally into the existing CSS grid (`grid-cols-2 sm:grid-cols-3 lg:grid-cols-4`).

## Test Results

All 29 tests pass. Build succeeds.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646799) for issue #90

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22496646799, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22496646799 -->

<!-- gh-aw-workflow-id: repo-assist -->