### PR TITLE
[Pipeline] Fix gallery user sdrasner — correct username is sdras

### DIFF
--- a/src/data/gallery-users.ts
+++ b/src/data/gallery-users.ts
@@ -9,7 +9,7 @@ export const GALLERY_USERS: GalleryUser[] = [
   { username: "sindresorhus", tagline: "Prolific open-source maintainer" },
   { username: "addyosmani", tagline: "Engineering manager at Google Chrome" },
   { username: "kentcdodds", tagline: "Creator of Testing Library" },
-  { username: "sdrasner", tagline: "Core Vue.js team member" },
+  { username: "sdras", tagline: "Core Vue.js team member" },
   { username: "ThePrimeagen", tagline: "Developer educator and Neovim advocate" },
   { username: "octocat", tagline: "GitHub's mascot" },
   { username: "steipete", tagline: "Creator of OpenClaw" },


### PR DESCRIPTION
Closes #103

## Changes

Changed the gallery username from `sdrasner` to `sdras` — Sarah Drasner's actual GitHub handle.

- `src/data/gallery-users.ts`: Updated username entry from `sdrasner` to `sdras`

## Test Results

All 29 tests pass. ✅

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497395381) for issue #101

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497395381, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497395381 -->

<!-- gh-aw-workflow-id: repo-assist -->