### PR TITLE
[Pipeline] Fix share URL input — resolve SSR hydration mismatch on card page

### DIFF
--- a/src/app/card/[username]/card-view.tsx
+++ b/src/app/card/[username]/card-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import DevCard from "@/components/card/dev-card";
 import ThemeSelector from "@/components/card/theme-selector";
@@ -15,7 +15,12 @@ interface CardViewProps {
 
 export default function CardView({ data, username }: CardViewProps) {
   const [theme, setTheme] = useState("midnight");
+  const [shareUrl, setShareUrl] = useState(`/card/${username}`);
   const currentTheme = THEMES.find((t) => t.id === theme) ?? THEMES[0];
+
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
 
   return (
     <motion.div
@@ -32,7 +37,7 @@ export default function CardView({ data, username }: CardViewProps) {
         <input
           type="text"
           readOnly
-          value={typeof window !== "undefined" ? window.location.href : `/card/${username}`}
+          value={shareUrl}
           className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-300 w-72 text-center outline-none"
         />
       </div>


### PR DESCRIPTION
Closes #104

## Changes

Fixed the hydration mismatch in the share URL input on the card page.

**Root cause:** The component was reading `window.location.href` inline during render, which doesn't work during SSR and causes React to output a different value than the server-rendered fallback, resulting in the root URL `/` being displayed.

**Fix:** Used `useState` (initialized to the deterministic `/card/${username}`) + `useEffect` to update to `window.location.href` after mount. This is SSR-safe and avoids the hydration mismatch.

- `src/app/card/[username]/card-view.tsx`: Added `useEffect` import and `shareUrl` state; replaced inline `window.location.href` check with the state value

## Test Results

All 29 tests pass. ✅

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497395381) for issue #101

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497395381, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497395381 -->

<!-- gh-aw-workflow-id: repo-assist -->