### PR TITLE
[Pipeline] DevCard visual separation — add subtle shadow for all non-Neon themes

### DIFF
--- a/src/components/card/dev-card.tsx
+++ b/src/components/card/dev-card.tsx
@@ -31,7 +31,7 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
         flexDirection: "column",
         padding: "1.5rem",
         boxSizing: "border-box",
-        ...(isNeon ? { boxShadow: activeTheme.borderColor } : {}),
+        ...(isNeon ? { boxShadow: activeTheme.borderColor } : { boxShadow: "0 0 0 1px rgba(255,255,255,0.1), 0 4px 24px rgba(0,0,0,0.3)" }),
       }}
     >
       {/* Profile Section */}


### PR DESCRIPTION
Closes #102

## Changes

Added a subtle `boxShadow` to the DevCard root element for all non-Neon themes, providing clear visual separation from dark page backgrounds.

**Fix:** The conditional `boxShadow` style on the card root now applies `0 0 0 1px rgba(255,255,255,0.1), 0 4px 24px rgba(0,0,0,0.3)` for all themes except Neon (which retains its existing glow effect). This gives:
- A thin 1px semi-transparent white border outline
- A soft dark drop shadow

- `src/components/card/dev-card.tsx`: Updated the `isNeon` spread to provide a shadow for non-neon themes instead of an empty object

## Test Results

All 29 tests pass. ✅

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497395381) for issue #101

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497395381, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497395381 -->

<!-- gh-aw-workflow-id: repo-assist -->