### PR TITLE
[Pipeline] Fix gallery card clipping — correct container dimensions for scaled cards

### DIFF
--- a/src/app/gallery/gallery-grid.tsx
+++ b/src/app/gallery/gallery-grid.tsx
@@ -26,8 +26,8 @@ export default function GalleryGrid({ cards }: GalleryGridProps) {
           transition={{ delay: i * 0.05 }}
         >
           <Link href={`/card/${user.username}`} className="block">
-            <div style={{ height: 400, overflow: "hidden", position: "relative" }}>
-              <div style={{ transform: "scale(0.75)", transformOrigin: "top center" }}>
+            <div style={{ width: 300, height: 420, overflow: "hidden", position: "relative" }}>
+              <div style={{ transform: "scale(0.75)", transformOrigin: "top left", width: 400 }}>
                 <DevCard data={data} theme="midnight" />
               </div>
             </div>


### PR DESCRIPTION
Closes #101

## Changes

Fixed the gallery card container so scaled DevCards are no longer clipped.

**Root cause:** The DevCard is 400×560px. At `scale(0.75)` it renders at 300×420px. The container was 400px tall (`height: 400`) — too short for the 420px scaled card — and used `transform-origin: top center` which caused horizontal clipping on narrower columns.

**Fix:**
- Container dimensions changed to `width: 300, height: 420` (exactly matching the scaled card output: 400×0.75 = 300, 560×0.75 = 420)
- `transform-origin` changed from `top center` to `top left` so the scale anchor matches the container's top-left corner, preventing any horizontal overflow

- `src/app/gallery/gallery-grid.tsx`: Updated container dimensions and transform-origin

## Test Results

All 29 tests pass. ✅

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497395381) for issue #101

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497395381, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497395381 -->

<!-- gh-aw-workflow-id: repo-assist -->