### PR TITLE
[Pipeline] Fix gallery user sdrasner — correct username is sdras

### DIFF
--- a/src/data/gallery-users.ts
+++ b/src/data/gallery-users.ts
@@ -9,7 +9,7 @@ export const GALLERY_USERS: GalleryUser[] = [
   { username: "sindresorhus", tagline: "Prolific open-source maintainer" },
   { username: "addyosmani", tagline: "Engineering manager at Google Chrome" },
   { username: "kentcdodds", tagline: "Creator of Testing Library" },
-  { username: "sdrasner", tagline: "Core Vue.js team member" },
+  { username: "sdras", tagline: "Core Vue.js team member" },
   { username: "ThePrimeagen", tagline: "Developer educator and Neovim advocate" },
   { username: "octocat", tagline: "GitHub's mascot" },
   { username: "steipete", tagline: "Creator of OpenClaw" },


### PR DESCRIPTION
Closes #103

## Changes

Changed the gallery username from `sdrasner` to `sdras` in `src/data/gallery-users.ts`. Sarah Drasner's actual GitHub username is `sdras` — `sdrasner` returns 404 from the GitHub API.

## Test Results

All 29 tests passing (11 test files).

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497426013) for issue #104

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497426013, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497426013 -->

<!-- gh-aw-workflow-id: repo-assist -->