### PR TITLE
[Pipeline] Fix gallery cards clip text — correct scale container dimensions

### DIFF
--- a/src/app/gallery/gallery-grid.tsx
+++ b/src/app/gallery/gallery-grid.tsx
@@ -26,8 +26,8 @@ export default function GalleryGrid({ cards }: GalleryGridProps) {
           transition={{ delay: i * 0.05 }}
         >
           <Link href={`/card/${user.username}`} className="block">
-            <div style={{ height: 400, overflow: "hidden", position: "relative" }}>
-              <div style={{ transform: "scale(0.75)", transformOrigin: "top center" }}>
+            <div style={{ width: 300, height: 420, overflow: "hidden", position: "relative" }}>
+              <div style={{ transform: "scale(0.75)", transformOrigin: "top left", width: 400, height: 560, flexShrink: 0 }}>
                 <DevCard data={data} theme="midnight" />
               </div>
             </div>


### PR DESCRIPTION
Closes #101

## Changes

Fixed gallery card clipping in `src/app/gallery/gallery-grid.tsx` by correcting the container dimensions to match the visual output of the scaled card.

**Root cause:** CSS `transform: scale()` does not affect layout flow — the original 560px card still occupied 560px even when visually scaled to 0.75. With `overflow: hidden`, content beyond the container height was clipped.

**Fix:**
- Outer container: `width: 300, height: 420` (= 400×0.75 × 560×0.75) — matches the visual size of the scaled card
- Inner wrapper: `transformOrigin: "top left"` so the card scales to exactly fit the 300×420 container
- No content is clipped horizontally or vertically

## Test Results

All 29 tests passing (11 test files).

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497426013) for issue #104

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497426013, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497426013 -->

<!-- gh-aw-workflow-id: repo-assist -->