### PR TITLE
[Pipeline] Fix DevCard visual separation — add subtle box-shadow to non-neon themes

### DIFF
--- a/src/components/card/dev-card.tsx
+++ b/src/components/card/dev-card.tsx
@@ -31,7 +31,7 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
         flexDirection: "column",
         padding: "1.5rem",
         boxSizing: "border-box",
-        ...(isNeon ? { boxShadow: activeTheme.borderColor } : {}),
+        ...(isNeon ? { boxShadow: activeTheme.borderColor } : { boxShadow: "0 0 0 1px rgba(255,255,255,0.1), 0 4px 24px rgba(0,0,0,0.3)" }),
       }}
     >
       {/* Profile Section */}


### PR DESCRIPTION
Closes #102

## Changes

Added a subtle `boxShadow` to all non-Neon DevCard themes in `src/components/card/dev-card.tsx`.

**Before:** Non-neon themes had no shadow or border on the card root, causing the card's dark background to blend into the page background with no visual separation.

**After:** A soft inner ring (`0 0 0 1px rgba(255,255,255,0.1)`) plus a drop shadow (`0 4px 24px rgba(0,0,0,0.3)`) are applied to all themes except Neon. The Neon theme's existing glow effect is preserved unchanged.

This applies cleanly to all 6 themes (Midnight, Aurora, Sunset, Neon, Mono, Arctic).

## Test Results

All 29 tests passing (11 test files).

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497426013) for issue #104

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497426013, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497426013 -->

<!-- gh-aw-workflow-id: repo-assist -->