### PR TITLE
[Pipeline] Fix share URL input showing wrong path on card page

### DIFF
--- a/src/app/card/[username]/card-view.tsx
+++ b/src/app/card/[username]/card-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import DevCard from "@/components/card/dev-card";
 import ThemeSelector from "@/components/card/theme-selector";
@@ -16,6 +16,11 @@ interface CardViewProps {
 export default function CardView({ data, username }: CardViewProps) {
   const [theme, setTheme] = useState("midnight");
   const currentTheme = THEMES.find((t) => t.id === theme) ?? THEMES[0];
+  const [shareUrl, setShareUrl] = useState(`/card/${username}`);
+
+  useEffect(() => {
+    setShareUrl(`${window.location.origin}/card/${username}`);
+  }, [username]);
 
   return (
     <motion.div
@@ -32,7 +37,7 @@ export default function CardView({ data, username }: CardViewProps) {
         <input
           type="text"
           readOnly
-          value={typeof window !== "undefined" ? window.location.href : `/card/${username}`}
+          value={shareUrl}
           className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-300 w-72 text-center outline-none"
         />
       </div>


### PR DESCRIPTION
Closes #104

## Changes

Fixed share URL hydration mismatch on the card page. The previous `window.location.href` inline expression caused the server to render `/card/${username}` while the client sometimes picked up a stale value.

**Fix:** Added `useEffect` + `useState` to read `window.location.href` after mount, initializing with the SSR-safe `/card/${username}` and updating to the full URL (`${window.location.origin}/card/${username}`) on the client.

**File changed:** `src/app/card/[username]/card-view.tsx`

## Test Results

All 29 tests pass (`npm test`).

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497425327) for issue #103

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497425327, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497425327 -->

<!-- gh-aw-workflow-id: repo-assist -->