### PR TITLE
[Pipeline] Fix share URL input — resolve hydration mismatch on card page

### DIFF
--- a/src/app/card/[username]/card-view.tsx
+++ b/src/app/card/[username]/card-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import DevCard from "@/components/card/dev-card";
 import ThemeSelector from "@/components/card/theme-selector";
@@ -16,6 +16,11 @@ interface CardViewProps {
 export default function CardView({ data, username }: CardViewProps) {
   const [theme, setTheme] = useState("midnight");
   const currentTheme = THEMES.find((t) => t.id === theme) ?? THEMES[0];
+  const [shareUrl, setShareUrl] = useState(`/card/${username}`);
+
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
 
   return (
     <motion.div
@@ -32,7 +37,7 @@ export default function CardView({ data, username }: CardViewProps) {
         <input
           type="text"
           readOnly
-          value={typeof window !== "undefined" ? window.location.href : `/card/${username}`}
+          value={shareUrl}
           className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-300 w-72 text-center outline-none"
         />
       </div>


### PR DESCRIPTION
Closes #104

## Changes

Fixed the share URL hydration mismatch in `src/app/card/[username]/card-view.tsx`.

**Root cause:** `window.location.href` was called directly in render, causing a React hydration mismatch. The server rendered `/card/{username}` (the fallback), but the client could pick up a stale/root value from `window.location.href` before the component fully hydrated.

**Fix:** Replaced the inline ternary with a `useEffect` + `useState` pattern:
- Initial state: deterministic SSR-safe `/card/{username}` path (no flash of wrong value)
- After mount: `useEffect` updates to `window.location.href` (full absolute URL)

This ensures the share URL is always correct and there is no hydration mismatch.

## Test Results

All 29 tests passing (11 test files).

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497426013) for issue #104

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497426013, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497426013 -->

<!-- gh-aw-workflow-id: repo-assist -->