### PR TITLE
[Pipeline] Add visual separation to DevCard — box-shadow for page background contrast

### DIFF
--- a/src/components/card/dev-card.tsx
+++ b/src/components/card/dev-card.tsx
@@ -31,7 +31,9 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
         flexDirection: "column",
         padding: "1.5rem",
         boxSizing: "border-box",
-        ...(isNeon ? { boxShadow: activeTheme.borderColor } : {}),
+        ...(isNeon
+          ? { boxShadow: activeTheme.borderColor }
+          : { boxShadow: "0 0 0 1px rgba(255,255,255,0.1), 0 4px 24px rgba(0,0,0,0.3)" }),
       }}
     >
       {/* Profile Section */}


### PR DESCRIPTION
Closes #102

## Changes

Added a subtle `box-shadow` to the `DevCard` root element so it is visually separated from dark page backgrounds across all themes.

- Non-neon themes: `0 0 0 1px rgba(255,255,255,0.1), 0 4px 24px rgba(0,0,0,0.3)` — a thin white ring and soft drop shadow
- Neon theme: retains its existing glow effect unchanged

**File changed:** `src/components/card/dev-card.tsx` (3 lines)

## Test Results

All 29 tests pass (`npm test`).

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497425327) for issue #103

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497425327, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497425327 -->

<!-- gh-aw-workflow-id: repo-assist -->