### PR TITLE
[Pipeline] Fix gallery cards clipping — correct container dimensions for scaled DevCards

### DIFF
--- a/src/app/gallery/gallery-grid.tsx
+++ b/src/app/gallery/gallery-grid.tsx
@@ -26,8 +26,8 @@ export default function GalleryGrid({ cards }: GalleryGridProps) {
           transition={{ delay: i * 0.05 }}
         >
           <Link href={`/card/${user.username}`} className="block">
-            <div style={{ height: 400, overflow: "hidden", position: "relative" }}>
-              <div style={{ transform: "scale(0.75)", transformOrigin: "top center" }}>
+            <div style={{ width: 300, height: 420, overflow: "hidden", position: "relative" }}>
+              <div style={{ transform: "scale(0.75)", transformOrigin: "top left" }}>
                 <DevCard data={data} theme="midnight" />
               </div>
             </div>


### PR DESCRIPTION
Closes #101

## Changes

Fixed gallery card clipping by correctly sizing the container to match the scaled card dimensions and using `top left` transform origin.

**Before:**
- Container: `height: 400` — too small for `560px × 0.75 = 420px` scaled card
- `transformOrigin: "top center"` — caused unpredictable horizontal positioning

**After:**
- Container: `width: 300, height: 420` — exactly matches scaled card (`400×0.75`, `560×0.75`)
- `transformOrigin: "top left"` — card anchors to top-left of container, no overflow

**File changed:** `src/app/gallery/gallery-grid.tsx` (2 lines)

## Test Results

All 29 tests pass (`npm test`).

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497425327) for issue #103

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497425327, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497425327 -->

<!-- gh-aw-workflow-id: repo-assist -->