### PR TITLE
[Pipeline] Fix share URL hydration mismatch on card page

### DIFF
--- a/src/app/card/[username]/card-view.tsx
+++ b/src/app/card/[username]/card-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import DevCard from "@/components/card/dev-card";
 import ThemeSelector from "@/components/card/theme-selector";
@@ -15,7 +15,12 @@ interface CardViewProps {
 
 export default function CardView({ data, username }: CardViewProps) {
   const [theme, setTheme] = useState("midnight");
+  const [shareUrl, setShareUrl] = useState(`/card/${username}`);
   const currentTheme = THEMES.find((t) => t.id === theme) ?? THEMES[0];
+
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
 
   return (
     <motion.div
@@ -32,7 +37,7 @@ export default function CardView({ data, username }: CardViewProps) {
         <input
           type="text"
           readOnly
-          value={typeof window !== "undefined" ? window.location.href : `/card/${username}`}
+          value={shareUrl}
           className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-300 w-72 text-center outline-none"
         />
       </div>


### PR DESCRIPTION
Closes #104

## Changes

Fixed SSR hydration mismatch in `src/app/card/[username]/card-view.tsx`:

- Added `useEffect` to read `window.location.href` after component mounts
- Initial SSR-safe value is `/card/{username}` (no flash of wrong value)
- After mount, `useEffect` sets the full absolute URL via `window.location.href`

## Test Results

All 29 tests passing (11 test files).

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497415703) for issue #102

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497415703, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497415703 -->

<!-- gh-aw-workflow-id: repo-assist -->