### PR TITLE
[Pipeline] Add box-shadow to DevCard for visual separation from page background

### DIFF
--- a/src/components/card/dev-card.tsx
+++ b/src/components/card/dev-card.tsx
@@ -31,7 +31,9 @@ export default function DevCard({ data, theme = "midnight" }: DevCardProps) {
         flexDirection: "column",
         padding: "1.5rem",
         boxSizing: "border-box",
-        ...(isNeon ? { boxShadow: activeTheme.borderColor } : {}),
+        ...(isNeon
+          ? { boxShadow: activeTheme.borderColor }
+          : { boxShadow: "0 0 0 1px rgba(255,255,255,0.08), 0 4px 24px rgba(0,0,0,0.4)" }),
       }}
     >
       {/* Profile Section */}


### PR DESCRIPTION
Closes #102

## Changes

Added a subtle `boxShadow` to the DevCard root div in `src/components/card/dev-card.tsx` for all non-Neon themes:

```
0 0 0 1px rgba(255,255,255,0.08), 0 4px 24px rgba(0,0,0,0.4)
```

- The `1px` inset ring provides a thin light border visible on dark backgrounds
- The `4px 24px` drop-shadow adds depth separation from the page
- The Neon theme's existing glow shadow is preserved unchanged

## Test Results

All 29 tests passing (11 test files).

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497415703) for issue #102

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497415703, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497415703 -->

<!-- gh-aw-workflow-id: repo-assist -->