### PR TITLE
[Pipeline] Fix gallery card clipping — correct container dimensions for 0.75 scale

### DIFF
--- a/src/app/gallery/gallery-grid.tsx
+++ b/src/app/gallery/gallery-grid.tsx
@@ -26,8 +26,8 @@ export default function GalleryGrid({ cards }: GalleryGridProps) {
           transition={{ delay: i * 0.05 }}
         >
           <Link href={`/card/${user.username}`} className="block">
-            <div style={{ height: 400, overflow: "hidden", position: "relative" }}>
-              <div style={{ transform: "scale(0.75)", transformOrigin: "top center" }}>
+            <div style={{ width: 300, height: 420, overflow: "hidden", position: "relative", margin: "0 auto" }}>
+              <div style={{ transform: "scale(0.75)", transformOrigin: "top left" }}>
                 <DevCard data={data} theme="midnight" />
               </div>
             </div>


### PR DESCRIPTION
Closes #101

## Changes

Fixed gallery card clipping in `src/app/gallery/gallery-grid.tsx`:

- **Container dimensions**: Changed `height: 400` → `width: 300, height: 420` to match the actual scaled card dimensions (400×560 at scale 0.75 = 300×420px)
- **Transform origin**: Changed `transformOrigin: "top center"` → `transformOrigin: "top left"` so the scaled card aligns flush to the top-left of the container, preventing horizontal overflow
- **Centering**: Added `margin: "0 auto"` on the container so cards remain centered in their grid cells

Before: cards clipped at bottom (container 400px < scaled card 420px) and potentially on the right side due to scale origin mismatch.
After: full card content visible with no horizontal or vertical clipping.

## Test Results

All 29 tests passing (11 test files).

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497415703) for issue #102

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22497415703, workflow_id: repo-assist, run: https://github.com/samuelkahessay/agentic-pipeline/actions/runs/22497415703 -->

<!-- gh-aw-workflow-id: repo-assist -->