### PR TITLE
[Pipeline] Knowledge Base CRUD Endpoints & Seed Data

### DIFF
--- a/TicketDeflection.Tests/KnowledgeEndpointTests.cs
+++ b/TicketDeflection.Tests/KnowledgeEndpointTests.cs
@@ -1,0 +1,135 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using TicketDeflection.Data;
+
+namespace TicketDeflection.Tests;
+
+public class KnowledgeEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public KnowledgeEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetKnowledge_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/knowledge");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SeedData_Loads12PlusArticles()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TicketDbContext>();
+        var count = await db.KnowledgeArticles.CountAsync();
+        Assert.True(count >= 12, $"Expected at least 12 articles, got {count}");
+    }
+
+    [Fact]
+    public async Task SeedData_HasArticlesForAllCategories()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TicketDbContext>();
+
+        var categories = await db.KnowledgeArticles
+            .Select(a => a.Category)
+            .Distinct()
+            .ToListAsync();
+
+        Assert.Contains(TicketDeflection.Models.TicketCategory.Bug, categories);
+        Assert.Contains(TicketDeflection.Models.TicketCategory.HowTo, categories);
+        Assert.Contains(TicketDeflection.Models.TicketCategory.FeatureRequest, categories);
+        Assert.Contains(TicketDeflection.Models.TicketCategory.AccountIssue, categories);
+        Assert.Contains(TicketDeflection.Models.TicketCategory.Other, categories);
+    }
+
+    [Fact]
+    public async Task PostKnowledge_ReturnsCreated()
+    {
+        var response = await _client.PostAsJsonAsync("/api/knowledge", new
+        {
+            title = "Test Article",
+            content = "Test content",
+            tags = "test,article",
+            category = "Bug"
+        });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+    }
+
+    [Fact]
+    public async Task GetKnowledge_NotFound_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/knowledge/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteKnowledge_NotFound_Returns404()
+    {
+        var response = await _client.DeleteAsync($"/api/knowledge/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetKnowledge_FilterByCategory_ReturnsFiltered()
+    {
+        var response = await _client.GetAsync("/api/knowledge?category=Bug");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var articles = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(articles.GetArrayLength() >= 1);
+        foreach (var article in articles.EnumerateArray())
+            Assert.Equal("Bug", article.GetProperty("category").GetString());
+    }
+
+    [Fact]
+    public async Task PostThenGetKnowledge_ReturnsArticle()
+    {
+        var createResp = await _client.PostAsJsonAsync("/api/knowledge", new
+        {
+            title = "How-to Guide",
+            content = "Step by step instructions.",
+            tags = "guide,howto",
+            category = "HowTo"
+        });
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+
+        var location = createResp.Headers.Location!.ToString();
+        var getResp = await _client.GetAsync(location);
+        Assert.Equal(HttpStatusCode.OK, getResp.StatusCode);
+
+        var article = await getResp.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("How-to Guide", article.GetProperty("title").GetString());
+        Assert.Equal("HowTo", article.GetProperty("category").GetString());
+    }
+
+    [Fact]
+    public async Task DeleteKnowledge_DeletesSuccessfully()
+    {
+        var createResp = await _client.PostAsJsonAsync("/api/knowledge", new
+        {
+            title = "Delete me",
+            content = "Content to delete",
+            tags = "temp",
+            category = "Other"
+        });
+        var location = createResp.Headers.Location!.ToString();
+
+        var deleteResp = await _client.DeleteAsync(location);
+        Assert.Equal(HttpStatusCode.NoContent, deleteResp.StatusCode);
+
+        var getResp = await _client.GetAsync(location);
+        Assert.Equal(HttpStatusCode.NotFound, getResp.StatusCode);
+    }
+}

--- a/TicketDeflection/DTOs/KnowledgeDtos.cs
+++ b/TicketDeflection/DTOs/KnowledgeDtos.cs
@@ -1,0 +1,11 @@
+namespace TicketDeflection.DTOs;
+
+public record CreateKnowledgeRequest(string Title, string Content, string Tags, string Category);
+
+public record KnowledgeResponse(
+    Guid Id,
+    string Title,
+    string Content,
+    string Tags,
+    string Category
+);

--- a/TicketDeflection/Data/SeedData.cs
+++ b/TicketDeflection/Data/SeedData.cs
@@ -1,0 +1,103 @@
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Data;
+
+public static class SeedData
+{
+    public static void Initialize(TicketDbContext context)
+    {
+        if (context.KnowledgeArticles.Any())
+            return;
+
+        var articles = new[]
+        {
+            new KnowledgeArticle
+            {
+                Title = "Common Error Codes",
+                Content = "Error 500 means internal server error. Error 404 means not found. Error 403 means forbidden access.",
+                Tags = "error,500,404,server,http",
+                Category = TicketCategory.Bug
+            },
+            new KnowledgeArticle
+            {
+                Title = "Crash Recovery Guide",
+                Content = "If the application crashes, restart it using the service manager. Check logs in /var/log for details.",
+                Tags = "crash,recovery,restart,logs",
+                Category = TicketCategory.Bug
+            },
+            new KnowledgeArticle
+            {
+                Title = "How to Export Data",
+                Content = "Navigate to Settings > Export and choose CSV or JSON format. Large exports may take several minutes.",
+                Tags = "export,data,csv,json,settings",
+                Category = TicketCategory.HowTo
+            },
+            new KnowledgeArticle
+            {
+                Title = "Getting Started Guide",
+                Content = "Welcome! Create your account, verify your email, then explore the dashboard. Use the help button for tooltips.",
+                Tags = "onboarding,start,setup,account,dashboard",
+                Category = TicketCategory.HowTo
+            },
+            new KnowledgeArticle
+            {
+                Title = "How to Configure Notifications",
+                Content = "Go to Profile > Notifications to enable or disable email and in-app alerts for events.",
+                Tags = "notifications,email,alerts,settings,profile",
+                Category = TicketCategory.HowTo
+            },
+            new KnowledgeArticle
+            {
+                Title = "Feature Request Process",
+                Content = "Submit feature requests via our feedback portal. We review all requests quarterly and prioritise by vote count.",
+                Tags = "feature,request,feedback,roadmap",
+                Category = TicketCategory.FeatureRequest
+            },
+            new KnowledgeArticle
+            {
+                Title = "Planned Feature Roadmap",
+                Content = "Upcoming features include dark mode, API v2, and bulk operations. Check our public roadmap for timelines.",
+                Tags = "roadmap,feature,upcoming,api,dark-mode",
+                Category = TicketCategory.FeatureRequest
+            },
+            new KnowledgeArticle
+            {
+                Title = "Password Reset Guide",
+                Content = "Click 'Forgot Password' on the login page, enter your email, and follow the reset link sent to your inbox.",
+                Tags = "password,reset,login,email,account",
+                Category = TicketCategory.AccountIssue
+            },
+            new KnowledgeArticle
+            {
+                Title = "Billing FAQ",
+                Content = "Subscriptions renew monthly on the same date. To cancel, go to Billing > Cancel Subscription. Refunds are available within 7 days.",
+                Tags = "billing,subscription,cancel,refund,payment",
+                Category = TicketCategory.AccountIssue
+            },
+            new KnowledgeArticle
+            {
+                Title = "Two-Factor Authentication Setup",
+                Content = "Enable 2FA under Security settings. Use an authenticator app like Google Authenticator or Authy.",
+                Tags = "2fa,security,authentication,totp,account",
+                Category = TicketCategory.AccountIssue
+            },
+            new KnowledgeArticle
+            {
+                Title = "Service Status and Uptime",
+                Content = "Check our status page at status.example.com for real-time information about outages and maintenance windows.",
+                Tags = "status,uptime,outage,maintenance,service",
+                Category = TicketCategory.Other
+            },
+            new KnowledgeArticle
+            {
+                Title = "Contact Support",
+                Content = "Reach our support team via email at support@example.com or through the in-app chat widget, available 9–5 weekdays.",
+                Tags = "support,contact,email,chat,help",
+                Category = TicketCategory.Other
+            }
+        };
+
+        context.KnowledgeArticles.AddRange(articles);
+        context.SaveChanges();
+    }
+}

--- a/TicketDeflection/Endpoints/KnowledgeEndpoints.cs
+++ b/TicketDeflection/Endpoints/KnowledgeEndpoints.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using TicketDeflection.Data;
+using TicketDeflection.DTOs;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Endpoints;
+
+public static class KnowledgeEndpoints
+{
+    public static void MapKnowledgeEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/knowledge");
+
+        group.MapPost("/", CreateArticle);
+        group.MapGet("/", GetArticles);
+        group.MapGet("/{id:guid}", GetArticle);
+        group.MapDelete("/{id:guid}", DeleteArticle);
+    }
+
+    private static async Task<Results<Created<KnowledgeResponse>, BadRequest>> CreateArticle(
+        CreateKnowledgeRequest request, TicketDbContext db)
+    {
+        if (!Enum.TryParse<TicketCategory>(request.Category, true, out var category))
+            return TypedResults.BadRequest();
+
+        var article = new KnowledgeArticle
+        {
+            Id = Guid.NewGuid(),
+            Title = request.Title,
+            Content = request.Content,
+            Tags = request.Tags,
+            Category = category,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        db.KnowledgeArticles.Add(article);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Created($"/api/knowledge/{article.Id}", ToResponse(article));
+    }
+
+    private static async Task<Ok<List<KnowledgeResponse>>> GetArticles(
+        TicketDbContext db, string? category = null)
+    {
+        var query = db.KnowledgeArticles.AsQueryable();
+
+        if (category != null && Enum.TryParse<TicketCategory>(category, true, out var c))
+            query = query.Where(a => a.Category == c);
+
+        var articles = (await query.ToListAsync()).Select(ToResponse).ToList();
+        return TypedResults.Ok(articles);
+    }
+
+    private static async Task<Results<Ok<KnowledgeResponse>, NotFound>> GetArticle(
+        Guid id, TicketDbContext db)
+    {
+        var article = await db.KnowledgeArticles.FindAsync(id);
+        if (article is null) return TypedResults.NotFound();
+        return TypedResults.Ok(ToResponse(article));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> DeleteArticle(
+        Guid id, TicketDbContext db)
+    {
+        var article = await db.KnowledgeArticles.FindAsync(id);
+        if (article is null) return TypedResults.NotFound();
+
+        db.KnowledgeArticles.Remove(article);
+        await db.SaveChangesAsync();
+
+        return TypedResults.NoContent();
+    }
+
+    private static KnowledgeResponse ToResponse(KnowledgeArticle a) => new(
+        a.Id, a.Title, a.Content, a.Tags, a.Category.ToString()
+    );
+}

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using TicketDeflection.Data;
+using TicketDeflection.Endpoints;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,8 +10,16 @@ builder.Services.AddRazorPages();
 
 var app = builder.Build();
 
+// Seed knowledge base on startup
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<TicketDbContext>();
+    SeedData.Initialize(context);
+}
+
 // --- Endpoint Mappings ---
 app.MapRazorPages();
+app.MapKnowledgeEndpoints();
 
 app.MapGet("/health", () => Results.Ok(new { status = "healthy", version = "1.0.0" }));
 


### PR DESCRIPTION
Closes #137

## Changes

Implements CRUD endpoints for knowledge articles and seeds the database with 12 articles covering all five `TicketCategory` values:

- **`TicketDeflection/DTOs/KnowledgeDtos.cs`** — Defines `CreateKnowledgeRequest` (Title, Content, Tags, Category) and `KnowledgeResponse` (all fields)
- **`TicketDeflection/Endpoints/KnowledgeEndpoints.cs`** — Static `MapKnowledgeEndpoints` extension method with:
  - `POST /api/knowledge` — creates an article, returns 201
  - `GET /api/knowledge` — returns all articles, supports optional `?category` filter
  - `GET /api/knowledge/{id}` — returns 200 or 404
  - `DELETE /api/knowledge/{id}` — returns 204 or 404
- **`TicketDeflection/Data/SeedData.cs`** — `SeedData.Initialize(context)` seeds 12 articles (idempotent, checks count first) covering: Bug (2), HowTo (3), FeatureRequest (2), AccountIssue (3), Other (2)
- **`TicketDeflection/Program.cs`** — Seed data initialized after `app.Build()` using a scoped `TicketDbContext`; `app.MapKnowledgeEndpoints()` registered
- **`TicketDeflection.Tests/KnowledgeEndpointTests.cs`** — Integration tests verifying seed data loads (>=12 articles), all categories are represented, and all endpoints return correct HTTP status codes

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22505405374)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22505405374, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22505405374 -->

<!-- gh-aw-workflow-id: repo-assist -->