### PR TITLE
[Pipeline] Ticket Classification Service & Classify Endpoint

### DIFF
--- a/TicketDeflection.Tests/ClassificationServiceTests.cs
+++ b/TicketDeflection.Tests/ClassificationServiceTests.cs
@@ -1,0 +1,74 @@
+using TicketDeflection.Models;
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Tests;
+
+public class ClassificationServiceTests
+{
+    private readonly ClassificationService _service = new();
+
+    [Fact]
+    public void Classify_CrashInTitle_ReturnsBugHigh()
+    {
+        var ticket = new Ticket { Title = "App crash on login", Description = "" };
+        _service.ClassifyTicket(ticket);
+        Assert.Equal(TicketCategory.Bug, ticket.Category);
+        Assert.Equal(TicketSeverity.High, ticket.Severity);
+        Assert.Equal(TicketStatus.Classified, ticket.Status);
+    }
+
+    [Fact]
+    public void Classify_HowDoIInDescription_ReturnsHowToLow()
+    {
+        var ticket = new Ticket { Title = "Help needed", Description = "How do I export data?" };
+        _service.ClassifyTicket(ticket);
+        Assert.Equal(TicketCategory.HowTo, ticket.Category);
+        Assert.Equal(TicketSeverity.Low, ticket.Severity);
+        Assert.Equal(TicketStatus.Classified, ticket.Status);
+    }
+
+    [Fact]
+    public void Classify_NoMatchingKeywords_ReturnsOtherMedium()
+    {
+        var ticket = new Ticket { Title = "Something happened", Description = "Not sure what." };
+        _service.ClassifyTicket(ticket);
+        Assert.Equal(TicketCategory.Other, ticket.Category);
+        Assert.Equal(TicketSeverity.Medium, ticket.Severity);
+        Assert.Equal(TicketStatus.Classified, ticket.Status);
+    }
+
+    [Fact]
+    public void Classify_ErrorKeyword_ReturnsBugHigh()
+    {
+        var ticket = new Ticket { Title = "404 error on homepage", Description = "" };
+        _service.ClassifyTicket(ticket);
+        Assert.Equal(TicketCategory.Bug, ticket.Category);
+        Assert.Equal(TicketSeverity.High, ticket.Severity);
+    }
+
+    [Fact]
+    public void Classify_AccountKeyword_ReturnsAccountIssueMedium()
+    {
+        var ticket = new Ticket { Title = "Cannot login to my account", Description = "" };
+        _service.ClassifyTicket(ticket);
+        Assert.Equal(TicketCategory.AccountIssue, ticket.Category);
+        Assert.Equal(TicketSeverity.Medium, ticket.Severity);
+    }
+
+    [Fact]
+    public void Classify_FeatureRequestKeyword_ReturnsFeatureRequestMedium()
+    {
+        var ticket = new Ticket { Title = "Feature request: dark mode", Description = "Would be nice to have" };
+        _service.ClassifyTicket(ticket);
+        Assert.Equal(TicketCategory.FeatureRequest, ticket.Category);
+        Assert.Equal(TicketSeverity.Medium, ticket.Severity);
+    }
+
+    [Fact]
+    public void Classify_CaseInsensitive_MatchesKeyword()
+    {
+        var ticket = new Ticket { Title = "CRASH in production", Description = "" };
+        _service.ClassifyTicket(ticket);
+        Assert.Equal(TicketCategory.Bug, ticket.Category);
+    }
+}

--- a/TicketDeflection.Tests/ClassifyEndpointTests.cs
+++ b/TicketDeflection.Tests/ClassifyEndpointTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using TicketDeflection.Data;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Tests;
+
+public class ClassifyEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ClassifyEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task<Guid> CreateTicketInDb(string title, string description = "desc")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TicketDbContext>();
+        var ticket = new Ticket { Title = title, Description = description, Source = "test" };
+        db.Tickets.Add(ticket);
+        await db.SaveChangesAsync();
+        return ticket.Id;
+    }
+
+    [Fact]
+    public async Task Classify_ExistingTicket_Returns200WithClassifiedStatus()
+    {
+        var id = await CreateTicketInDb("App crash on login");
+        var response = await _client.PostAsync($"/api/tickets/{id}/classify", null);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var ticket = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal("Classified", ticket.GetProperty("status").GetString());
+        Assert.Equal("Bug", ticket.GetProperty("category").GetString());
+        Assert.Equal("High", ticket.GetProperty("severity").GetString());
+    }
+
+    [Fact]
+    public async Task Classify_NonExistentTicket_Returns404()
+    {
+        var response = await _client.PostAsync($"/api/tickets/{Guid.NewGuid()}/classify", null);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/TicketDeflection/DTOs/TicketDtos.cs
+++ b/TicketDeflection/DTOs/TicketDtos.cs
@@ -1,0 +1,18 @@
+namespace TicketDeflection.DTOs;
+
+public record CreateTicketRequest(string Title, string Description, string Source);
+
+public record UpdateTicketRequest(string Title, string Description);
+
+public record TicketResponse(
+    Guid Id,
+    string Title,
+    string Description,
+    string Category,
+    string Severity,
+    string Status,
+    string? Resolution,
+    string Source,
+    DateTime CreatedAt,
+    DateTime UpdatedAt
+);

--- a/TicketDeflection/Endpoints/ClassifyEndpoints.cs
+++ b/TicketDeflection/Endpoints/ClassifyEndpoints.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using TicketDeflection.Data;
+using TicketDeflection.DTOs;
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Endpoints;
+
+public static class ClassifyEndpoints
+{
+    public static void MapClassifyEndpoints(this WebApplication app)
+    {
+        app.MapPost("/api/tickets/{id:guid}/classify", ClassifyTicket);
+    }
+
+    private static async Task<Results<Ok<TicketResponse>, NotFound>> ClassifyTicket(
+        Guid id, TicketDbContext db, ClassificationService classifier)
+    {
+        var ticket = await db.Tickets.FindAsync(id);
+        if (ticket is null) return TypedResults.NotFound();
+
+        classifier.ClassifyTicket(ticket);
+        await db.SaveChangesAsync();
+
+        return TypedResults.Ok(new TicketResponse(
+            ticket.Id, ticket.Title, ticket.Description,
+            ticket.Category.ToString(), ticket.Severity.ToString(), ticket.Status.ToString(),
+            ticket.Resolution, ticket.Source, ticket.CreatedAt, ticket.UpdatedAt
+        ));
+    }
+}

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -1,11 +1,13 @@
 using Microsoft.EntityFrameworkCore;
 using TicketDeflection.Data;
 using TicketDeflection.Endpoints;
+using TicketDeflection.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // --- Service Registrations ---
 builder.Services.AddDbContext<TicketDbContext>(o => o.UseInMemoryDatabase("TicketDb"));
+builder.Services.AddScoped<ClassificationService>();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
@@ -20,6 +22,7 @@ using (var scope = app.Services.CreateScope())
 // --- Endpoint Mappings ---
 app.MapRazorPages();
 app.MapKnowledgeEndpoints();
+app.MapClassifyEndpoints();
 
 app.MapGet("/health", () => Results.Ok(new { status = "healthy", version = "1.0.0" }));
 

--- a/TicketDeflection/Services/ClassificationService.cs
+++ b/TicketDeflection/Services/ClassificationService.cs
@@ -1,0 +1,42 @@
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Services;
+
+public class ClassificationService
+{
+    private static readonly (string[] Keywords, TicketCategory Category)[] Rules =
+    [
+        (["crash", "error", "broken", "bug", "exception"], TicketCategory.Bug),
+        (["how do i", "how to", "help with", "guide"], TicketCategory.HowTo),
+        (["add feature", "request", "wish", "would be nice"], TicketCategory.FeatureRequest),
+        (["login", "password", "account", "billing", "subscription"], TicketCategory.AccountIssue),
+    ];
+
+    private static readonly Dictionary<TicketCategory, TicketSeverity> SeverityMap = new()
+    {
+        [TicketCategory.Bug] = TicketSeverity.High,
+        [TicketCategory.HowTo] = TicketSeverity.Low,
+        [TicketCategory.FeatureRequest] = TicketSeverity.Medium,
+        [TicketCategory.AccountIssue] = TicketSeverity.Medium,
+        [TicketCategory.Other] = TicketSeverity.Medium,
+    };
+
+    public void ClassifyTicket(Ticket ticket)
+    {
+        var text = $"{ticket.Title} {ticket.Description}";
+        var category = TicketCategory.Other;
+
+        foreach (var (keywords, cat) in Rules)
+        {
+            if (keywords.Any(k => text.Contains(k, StringComparison.OrdinalIgnoreCase)))
+            {
+                category = cat;
+                break;
+            }
+        }
+
+        ticket.Category = category;
+        ticket.Severity = SeverityMap[category];
+        ticket.Status = TicketStatus.Classified;
+    }
+}


### PR DESCRIPTION
Closes #128

## Changes

Implements the Ticket Classification Service with keyword-based rules and a classify endpoint.

### Files Added
- **`TicketDeflection/Services/ClassificationService.cs`** — `ClassifyTicket(Ticket ticket)` method that classifies tickets using 15+ keyword rules across 4 categories (case-insensitive match against title + description), sets `Severity` based on category, and sets `Status = Classified`
- **`TicketDeflection/DTOs/TicketDtos.cs`** — `TicketResponse`, `CreateTicketRequest`, `UpdateTicketRequest` records
- **`TicketDeflection/Endpoints/ClassifyEndpoints.cs`** — `POST /api/tickets/{id}/classify` endpoint: looks up ticket, classifies it, persists, returns 200 with `TicketResponse` or 404 if not found
- **`TicketDeflection.Tests/ClassificationServiceTests.cs`** — 7 unit tests: crash→Bug/High, how-do-I→HowTo/Low, no-match→Other/Medium, error keyword, account keyword, feature request keyword, case-insensitive matching
- **`TicketDeflection.Tests/ClassifyEndpointTests.cs`** — 2 integration tests: classify existing ticket returns 200 with correct category/severity/status, non-existent ticket returns 404

### Modified
- **`TicketDeflection/Program.cs`** — registers `ClassificationService` as scoped (below `// --- Service Registrations ---`), maps classify endpoint (below `// --- Endpoint Mappings ---`)

### Keyword Rules
| Keywords | Category | Severity |
|---------|----------|---------|
| crash, error, broken, bug, exception | Bug | High |
| how do i, how to, help with, guide | HowTo | Low |
| add feature, request, wish, would be nice | FeatureRequest | Medium |
| login, password, account, billing, subscription | AccountIssue | Medium |
| _(no match)_ | Other | Medium |

> **Note**: `TicketDtos.cs` is also added in PR #141 (Ticket CRUD Endpoints). If both PRs merge, a minor conflict will need resolution — keeping all three DTOs from both PRs is correct.

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22506349782)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22506349782, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22506349782 -->

<!-- gh-aw-workflow-id: repo-assist -->