### PR TITLE
[Pipeline] Implement Ticket CRUD Minimal API Endpoints

### DIFF
--- a/TicketDeflection.Tests/TicketEndpointTests.cs
+++ b/TicketDeflection.Tests/TicketEndpointTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace TicketDeflection.Tests;
+
+public class TicketEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public TicketEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task POST_Ticket_Returns201WithLocation()
+    {
+        var request = new { Title = "Login fails", Description = "Users cannot log in", Source = "web" };
+        var response = await _client.PostAsJsonAsync("/api/tickets", request);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+    }
+
+    [Fact]
+    public async Task POST_Ticket_SetsStatusNew()
+    {
+        var request = new { Title = "Test ticket", Description = "Desc", Source = "api" };
+        var response = await _client.PostAsJsonAsync("/api/tickets", request);
+        var body = await response.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+
+        Assert.Equal("New", body.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public async Task GET_Tickets_Returns200WithList()
+    {
+        var response = await _client.GetAsync("/api/tickets");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GET_Ticket_Returns200ForExisting()
+    {
+        var createRequest = new { Title = "Find me", Description = "Desc", Source = "test" };
+        var created = await _client.PostAsJsonAsync("/api/tickets", createRequest);
+        var body = await created.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        var id = body.GetProperty("id").GetString();
+
+        var response = await _client.GetAsync($"/api/tickets/{id}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GET_Ticket_Returns404ForUnknown()
+    {
+        var response = await _client.GetAsync($"/api/tickets/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PUT_Ticket_Returns200WithUpdatedData()
+    {
+        var createRequest = new { Title = "Original", Description = "Old desc", Source = "test" };
+        var created = await _client.PostAsJsonAsync("/api/tickets", createRequest);
+        var body = await created.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        var id = body.GetProperty("id").GetString();
+
+        var updateRequest = new { Title = "Updated", Description = "New desc" };
+        var response = await _client.PutAsJsonAsync($"/api/tickets/{id}", updateRequest);
+        var updated = await response.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("Updated", updated.GetProperty("title").GetString());
+    }
+
+    [Fact]
+    public async Task PUT_Ticket_Returns404ForUnknown()
+    {
+        var updateRequest = new { Title = "Updated", Description = "New desc" };
+        var response = await _client.PutAsJsonAsync($"/api/tickets/{Guid.NewGuid()}", updateRequest);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DELETE_Ticket_Returns204()
+    {
+        var createRequest = new { Title = "Delete me", Description = "Desc", Source = "test" };
+        var created = await _client.PostAsJsonAsync("/api/tickets", createRequest);
+        var body = await created.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        var id = body.GetProperty("id").GetString();
+
+        var response = await _client.DeleteAsync($"/api/tickets/{id}");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DELETE_Ticket_Returns404ForUnknown()
+    {
+        var response = await _client.DeleteAsync($"/api/tickets/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/TicketDeflection/Endpoints/TicketEndpoints.cs
+++ b/TicketDeflection/Endpoints/TicketEndpoints.cs
@@ -1,0 +1,97 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using TicketDeflection.Data;
+using TicketDeflection.DTOs;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Endpoints;
+
+public static class TicketEndpoints
+{
+    public static void MapTicketEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/tickets");
+
+        group.MapPost("/", CreateTicket);
+        group.MapGet("/", GetTickets);
+        group.MapGet("/{id:guid}", GetTicket);
+        group.MapPut("/{id:guid}", UpdateTicket);
+        group.MapDelete("/{id:guid}", DeleteTicket);
+    }
+
+    private static async Task<Results<Created<TicketResponse>, BadRequest>> CreateTicket(
+        CreateTicketRequest request, TicketDbContext db)
+    {
+        var ticket = new Ticket
+        {
+            Id = Guid.NewGuid(),
+            Title = request.Title,
+            Description = request.Description,
+            Source = request.Source,
+            Status = TicketStatus.New,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.Tickets.Add(ticket);
+        await db.SaveChangesAsync();
+
+        var response = ToResponse(ticket);
+        return TypedResults.Created($"/api/tickets/{ticket.Id}", response);
+    }
+
+    private static async Task<Ok<List<TicketResponse>>> GetTickets(
+        TicketDbContext db, string? status = null, string? category = null)
+    {
+        var query = db.Tickets.AsQueryable();
+
+        if (status is not null && Enum.TryParse<TicketStatus>(status, true, out var statusEnum))
+            query = query.Where(t => t.Status == statusEnum);
+
+        if (category is not null && Enum.TryParse<TicketCategory>(category, true, out var categoryEnum))
+            query = query.Where(t => t.Category == categoryEnum);
+
+        var tickets = await query.Select(t => ToResponse(t)).ToListAsync();
+        return TypedResults.Ok(tickets);
+    }
+
+    private static async Task<Results<Ok<TicketResponse>, NotFound>> GetTicket(
+        Guid id, TicketDbContext db)
+    {
+        var ticket = await db.Tickets.FindAsync(id);
+        return ticket is null
+            ? TypedResults.NotFound()
+            : TypedResults.Ok(ToResponse(ticket));
+    }
+
+    private static async Task<Results<Ok<TicketResponse>, NotFound>> UpdateTicket(
+        Guid id, UpdateTicketRequest request, TicketDbContext db)
+    {
+        var ticket = await db.Tickets.FindAsync(id);
+        if (ticket is null) return TypedResults.NotFound();
+
+        ticket.Title = request.Title;
+        ticket.Description = request.Description;
+        ticket.UpdatedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync();
+        return TypedResults.Ok(ToResponse(ticket));
+    }
+
+    private static async Task<Results<NoContent, NotFound>> DeleteTicket(
+        Guid id, TicketDbContext db)
+    {
+        var ticket = await db.Tickets.FindAsync(id);
+        if (ticket is null) return TypedResults.NotFound();
+
+        db.Tickets.Remove(ticket);
+        await db.SaveChangesAsync();
+        return TypedResults.NoContent();
+    }
+
+    private static TicketResponse ToResponse(Ticket t) => new(
+        t.Id, t.Title, t.Description,
+        t.Category.ToString(), t.Severity.ToString(), t.Status.ToString(),
+        t.Resolution, t.Source, t.CreatedAt, t.UpdatedAt
+    );
+}

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -21,6 +21,7 @@ using (var scope = app.Services.CreateScope())
 
 // --- Endpoint Mappings ---
 app.MapRazorPages();
+app.MapTicketEndpoints();
 app.MapKnowledgeEndpoints();
 app.MapClassifyEndpoints();
 


### PR DESCRIPTION
Closes #127

## Changes

Implements five Minimal API endpoints for managing tickets in `TicketDeflection/Endpoints/TicketEndpoints.cs`:
- `POST /api/tickets` — creates ticket with `Status=New`, returns 201 with `Location` header
- `GET /api/tickets` — returns list with optional `?status=` and `?category=` filtering
- `GET /api/tickets/{id}` — returns 200 or 404
- `PUT /api/tickets/{id}` — updates Title/Description, sets UpdatedAt, returns 200 or 404
- `DELETE /api/tickets/{id}` — returns 204 or 404

### Files Changed
- **`TicketDeflection/Endpoints/TicketEndpoints.cs`** (new) — `MapTicketEndpoints` extension method
- **`TicketDeflection/Program.cs`** — registered `app.MapTicketEndpoints()` under `// --- Endpoint Mappings ---`
- **`TicketDeflection.Tests/TicketEndpointTests.cs`** (new) — 9 integration tests via `WebApplicationFactory`

### Test Coverage
All five endpoints tested for correct HTTP status codes via `WebApplicationFactory(Program)`.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22507373223)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22507373223, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22507373223 -->

<!-- gh-aw-workflow-id: repo-assist -->