### PR TITLE
[Pipeline] Ticket Pipeline Orchestrator & Submit Endpoint

### DIFF
--- a/TicketDeflection.Tests/PipelineServiceTests.cs
+++ b/TicketDeflection.Tests/PipelineServiceTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using TicketDeflection.Data;
+using TicketDeflection.Endpoints;
+using TicketDeflection.Models;
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Tests;
+
+public class PipelineServiceTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public PipelineServiceTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(b =>
+            b.ConfigureServices(services =>
+            {
+                var existing = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<TicketDbContext>));
+                if (existing != null) services.Remove(existing);
+                services.AddDbContext<TicketDbContext>(o =>
+                    o.UseInMemoryDatabase($"PipelineTestDb_{Guid.NewGuid()}"));
+            }));
+    }
+
+    [Fact]
+    public async Task Submit_PasswordReset_AutoResolved_WithActivityLogs()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/tickets/submit", new
+        {
+            title = "I cannot reset my password",
+            description = "I forgot my password and the reset email is not working login account",
+            source = "web"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        // Ticket should be auto-resolved
+        var status = root.GetProperty("ticket").GetProperty("status").GetString();
+        Assert.Equal("AutoResolved", status);
+
+        // Activity log should have at least 3 entries
+        var logs = root.GetProperty("activityLogs");
+        Assert.True(logs.GetArrayLength() >= 3);
+
+        // Verify log contains expected entries
+        var logActions = Enumerable.Range(0, logs.GetArrayLength())
+            .Select(i => logs[i].GetProperty("action").GetString())
+            .ToList();
+
+        Assert.Contains(logActions, a => a == "Ticket Created");
+        Assert.Contains(logActions, a => a != null && a.StartsWith("Ticket Classified as"));
+        Assert.Contains(logActions, a => a != null && (a.StartsWith("Ticket Matched") || a.StartsWith("Ticket Auto-Resolved")));
+    }
+
+    [Fact]
+    public async Task Submit_Gibberish_Escalated_WithActivityLogs()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/tickets/submit", new
+        {
+            title = "xyzzy qwerty zzzz",
+            description = "blargh foobar something nonsense",
+            source = "api"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        // Ticket should be escalated
+        var status = root.GetProperty("ticket").GetProperty("status").GetString();
+        Assert.Equal("Escalated", status);
+
+        // Activity log should have at least 3 entries
+        var logs = root.GetProperty("activityLogs");
+        Assert.True(logs.GetArrayLength() >= 3);
+    }
+
+    [Fact]
+    public async Task Submit_AnyTicket_ActivityLog_HasAtLeastThreeEntries()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/tickets/submit", new
+        {
+            title = "Some generic issue",
+            description = "I need some help",
+            source = "email"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var logs = doc.RootElement.GetProperty("activityLogs");
+        Assert.True(logs.GetArrayLength() >= 3);
+    }
+
+    [Fact]
+    public async Task Submit_EmptyDescription_ClassifiesAsOtherMedium()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/tickets/submit", new
+        {
+            title = "Something",
+            description = "",
+            source = "web"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        var category = root.GetProperty("classification").GetProperty("category").GetString();
+        var severity = root.GetProperty("classification").GetProperty("severity").GetString();
+
+        Assert.Equal("Other", category);
+        Assert.Equal("Medium", severity);
+    }
+}

--- a/TicketDeflection/Endpoints/PipelineEndpoints.cs
+++ b/TicketDeflection/Endpoints/PipelineEndpoints.cs
@@ -1,0 +1,45 @@
+using TicketDeflection.Data;
+using TicketDeflection.DTOs;
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Endpoints;
+
+public static class PipelineEndpoints
+{
+    public static void MapPipelineEndpoints(this WebApplication app)
+    {
+        app.MapPost("/api/tickets/submit", SubmitTicket);
+    }
+
+    private static async Task<IResult> SubmitTicket(
+        SubmitRequest request, TicketDbContext db, PipelineService pipeline)
+    {
+        var result = await pipeline.ProcessTicket(request.Title, request.Description, request.Source, db);
+
+        var ticketResponse = new TicketResponse(
+            result.Ticket.Id, result.Ticket.Title, result.Ticket.Description,
+            result.Category, result.Severity, result.Ticket.Status.ToString(),
+            result.Ticket.Resolution, result.Ticket.Source,
+            result.Ticket.CreatedAt, result.Ticket.UpdatedAt);
+
+        var response = new SubmitResponse(
+            ticketResponse,
+            new ClassificationDetails(result.Category, result.Severity),
+            new MatchResult(result.MatchedArticleTitle, result.MatchScore),
+            result.ActivityLogs
+                .Select(l => new ActivityLogEntry(l.Action, l.Details, l.Timestamp))
+                .ToList());
+
+        return Results.Ok(response);
+    }
+}
+
+public record SubmitRequest(string Title, string Description, string Source);
+public record ClassificationDetails(string Category, string Severity);
+public record MatchResult(string? ArticleTitle, double Score);
+public record ActivityLogEntry(string Action, string Details, DateTime Timestamp);
+public record SubmitResponse(
+    TicketResponse Ticket,
+    ClassificationDetails Classification,
+    MatchResult Match,
+    List<ActivityLogEntry> ActivityLogs);

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -9,6 +9,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<TicketDbContext>(o => o.UseInMemoryDatabase("TicketDb"));
 builder.Services.AddScoped<ClassificationService>();
 builder.Services.AddScoped<MatchingService>();
+builder.Services.AddScoped<PipelineService>();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
@@ -21,6 +22,7 @@ using (var scope = app.Services.CreateScope())
 }
 
 // --- Endpoint Mappings ---
+app.MapPipelineEndpoints();
 app.MapRazorPages();
 app.MapTicketEndpoints();
 app.MapKnowledgeEndpoints();

--- a/TicketDeflection/Services/PipelineService.cs
+++ b/TicketDeflection/Services/PipelineService.cs
@@ -1,0 +1,101 @@
+using TicketDeflection.Data;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Services;
+
+public record PipelineResult(
+    Ticket Ticket,
+    string Category,
+    string Severity,
+    string? MatchedArticleTitle,
+    double MatchScore,
+    List<ActivityLog> ActivityLogs);
+
+public class PipelineService
+{
+    private readonly ClassificationService _classifier;
+    private readonly MatchingService _matcher;
+
+    public PipelineService(ClassificationService classifier, MatchingService matcher)
+    {
+        _classifier = classifier;
+        _matcher = matcher;
+    }
+
+    public async Task<PipelineResult> ProcessTicket(
+        string title, string description, string source, TicketDbContext context)
+    {
+        var ticket = new Ticket
+        {
+            Title = title,
+            Description = description,
+            Source = source,
+            Status = TicketStatus.New
+        };
+
+        var logs = new List<ActivityLog>();
+
+        // Stage 1: Create ticket
+        context.Tickets.Add(ticket);
+        logs.Add(CreateLog(ticket.Id, "Ticket Created", $"Source: {source}"));
+
+        // Stage 2: Classify
+        _classifier.ClassifyTicket(ticket);
+        logs.Add(CreateLog(ticket.Id, $"Ticket Classified as {ticket.Category}/{ticket.Severity}", ""));
+
+        // Stage 3: Find best match score before resolving (for log entry)
+        var articles = context.KnowledgeArticles.ToList();
+        var ticketTokens = Tokenize($"{ticket.Title} {ticket.Description}");
+        double bestScore = 0;
+        KnowledgeArticle? bestArticle = null;
+        foreach (var article in articles)
+        {
+            var articleTokens = Tokenize($"{article.Content} {article.Tags}");
+            var score = Jaccard(ticketTokens, articleTokens);
+            if (score > bestScore)
+            {
+                bestScore = score;
+                bestArticle = article;
+            }
+        }
+
+        _matcher.ResolveTicket(ticket, context);
+
+        if (ticket.Status == TicketStatus.AutoResolved)
+        {
+            logs.Add(CreateLog(ticket.Id, $"Ticket Matched (score: {bestScore:F2})", $"Article: {bestArticle?.Title}"));
+            logs.Add(CreateLog(ticket.Id, $"Ticket Auto-Resolved: {bestArticle?.Title}", ticket.Resolution ?? ""));
+        }
+        else
+        {
+            logs.Add(CreateLog(ticket.Id, "Ticket Escalated (no match above threshold)", ""));
+            logs.Add(CreateLog(ticket.Id, "Ticket Escalated: no matching articles", ""));
+        }
+
+        context.ActivityLogs.AddRange(logs);
+        await context.SaveChangesAsync();
+
+        return new PipelineResult(ticket, ticket.Category.ToString(), ticket.Severity.ToString(),
+            bestArticle?.Title, bestScore, logs);
+    }
+
+    private static ActivityLog CreateLog(Guid ticketId, string action, string details) => new()
+    {
+        TicketId = ticketId,
+        Action = action,
+        Details = details
+    };
+
+    private static HashSet<string> Tokenize(string text) =>
+        text.Split([' ', '\t', ',', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(t => t.ToLowerInvariant())
+            .ToHashSet();
+
+    private static double Jaccard(HashSet<string> a, HashSet<string> b)
+    {
+        if (a.Count == 0 && b.Count == 0) return 0;
+        var intersection = a.Intersect(b).Count();
+        var union = a.Union(b).Count();
+        return intersection / (double)union;
+    }
+}


### PR DESCRIPTION
Closes #130

## Summary

Implements the full-pipeline orchestration service and `POST /api/tickets/submit` endpoint that chains the complete ticket lifecycle.

## Changes

### `TicketDeflection/Services/PipelineService.cs` (new)
- `ProcessTicket(title, description, source, context)` method chains:
  1. Creates `Ticket` with `Status = New`
  2. Calls `ClassificationService.ClassifyTicket`
  3. Computes best knowledge article match (Jaccard similarity)
  4. Calls `MatchingService.ResolveTicket`
  5. Writes 4 `ActivityLog` entries (Created → Classified → Matched/Escalated → AutoResolved/Escalated)
  6. Saves all to DB and returns `PipelineResult`

### `TicketDeflection/Endpoints/PipelineEndpoints.cs` (new)
- `MapPipelineEndpoints` extension method with `POST /api/tickets/submit`
- Returns JSON: ticket state, classification details, match result (article title + score), activity logs

### `TicketDeflection/Program.cs` (modified)
- Registered `PipelineService` as scoped in DI (below `// --- Service Registrations ---`)
- Mapped `MapPipelineEndpoints` before `MapTicketEndpoints` (route priority for `/api/tickets/submit`)

### `TicketDeflection.Tests/PipelineServiceTests.cs` (new)
- `Submit_PasswordReset_AutoResolved_WithActivityLogs` — password reset ticket → `AutoResolved` + ≥3 log entries
- `Submit_Gibberish_Escalated_WithActivityLogs` — nonsense ticket → `Escalated` + ≥3 log entries
- `Submit_AnyTicket_ActivityLog_HasAtLeastThreeEntries` — generic ticket has ≥3 log entries
- `Submit_EmptyDescription_ClassifiesAsOtherMedium` — empty description → `Other/Medium`

## Edge Cases Handled
- Empty description → classifies as `Other/Medium`, Jaccard matching still runs
- No knowledge matches → escalates with appropriate log entries

## Note
NuGet package restore unavailable in this agent environment (proxy restriction). Build and tests will run in GitHub Actions CI which has full internet access.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22508231439)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `api.nuget.org`
> - `dc.services.visualstudio.com`
>
> </details>


<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22508231439, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22508231439 -->

<!-- gh-aw-workflow-id: repo-assist -->