### PR TITLE
[Pipeline] Simulation Endpoint for Demo Data Generation

### DIFF
--- a/TicketDeflection.Tests/SimulateEndpointTests.cs
+++ b/TicketDeflection.Tests/SimulateEndpointTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using TicketDeflection.Data;
+
+namespace TicketDeflection.Tests;
+
+public class SimulateEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public SimulateEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(b =>
+            b.ConfigureServices(services =>
+            {
+                var existing = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<TicketDbContext>));
+                if (existing != null) services.Remove(existing);
+                services.AddDbContext<TicketDbContext>(o =>
+                    o.UseInMemoryDatabase($"SimulateTestDb_{Guid.NewGuid()}"));
+            }));
+    }
+
+    [Fact]
+    public async Task Simulate_Count5_Returns5Generated()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsync("/api/simulate?count=5", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        Assert.Equal(5, root.GetProperty("generated").GetInt32());
+
+        // autoResolved + escalated == generated
+        var autoResolved = root.GetProperty("autoResolved").GetInt32();
+        var escalated = root.GetProperty("escalated").GetInt32();
+        Assert.Equal(5, autoResolved + escalated);
+
+        // byCategory should be present and sum to 5
+        var byCategory = root.GetProperty("byCategory");
+        var total = 0;
+        foreach (var prop in byCategory.EnumerateObject())
+            total += prop.Value.GetInt32();
+        Assert.Equal(5, total);
+    }
+
+    [Fact]
+    public async Task Simulate_DefaultCount_Returns10Generated()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsync("/api/simulate", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(10, doc.RootElement.GetProperty("generated").GetInt32());
+    }
+
+    [Fact]
+    public async Task Simulate_ExceedsMax_CappedAt100()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsync("/api/simulate?count=200", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(100, doc.RootElement.GetProperty("generated").GetInt32());
+    }
+}

--- a/TicketDeflection/Endpoints/SimulateEndpoints.cs
+++ b/TicketDeflection/Endpoints/SimulateEndpoints.cs
@@ -1,0 +1,76 @@
+using TicketDeflection.Data;
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Endpoints;
+
+public static class SimulateEndpoints
+{
+    private static readonly (string Title, string Description, string Source)[] SampleTickets =
+    [
+        // Bug category (5 templates)
+        ("Application crashes on login", "The app throws a NullReferenceException when I try to log in with my Google account", "web"),
+        ("Data not saving after edit", "I edit my profile but after refreshing the page, changes are lost and nothing gets saved", "api"),
+        ("Export button not working", "Clicking the CSV export button does nothing — no download starts and no error appears", "email"),
+        ("Search returns wrong results", "When I search for 'invoice 2024' the results show completely unrelated documents", "web"),
+        ("Dark mode toggle broken", "Switching to dark mode causes the page to go blank — requires hard refresh to recover", "api"),
+        // HowTo category (5 templates)
+        ("How to reset my password", "I forgot my password and the reset email never arrived. How do I regain access to my account?", "web"),
+        ("How to export my data", "I need to download all my tickets and activity history as a CSV file for compliance reporting", "email"),
+        ("How to invite team members", "I want to add three colleagues to my workspace but cannot find the invite option in settings", "web"),
+        ("How to set up two-factor authentication", "I want to enable 2FA on my account for extra security but the setup wizard is confusing", "api"),
+        ("How to change notification settings", "I receive too many emails and want to reduce alerts to only critical issues", "email"),
+        // FeatureRequest category (5 templates)
+        ("Add bulk ticket assignment", "It would save time if we could select multiple open tickets and assign them to an agent at once", "web"),
+        ("Support dark mode in mobile app", "Many of us use the app at night and a dark theme would reduce eye strain significantly", "api"),
+        ("Add Slack integration for alerts", "We use Slack for all team communication and would love to get ticket alerts there", "email"),
+        ("Export metrics as PDF report", "Management requests monthly PDF summaries of resolution rates and ticket volumes", "web"),
+        ("Add ticket priority escalation rules", "Auto-escalate tickets that remain unresolved for more than 48 hours to high priority", "api"),
+        // AccountIssue category (5 templates)
+        ("Cannot access my account after password change", "I changed my password yesterday and now login fails even with the new credentials", "email"),
+        ("Subscription not activating", "I upgraded to Pro plan and was charged but my account still shows the free tier limitations", "web"),
+        ("Account locked after failed logins", "I got locked out after 5 wrong attempts during a browser autofill issue — need unlock help", "api"),
+        ("Two-factor code not accepted", "The authenticator app generates a code but the system keeps saying it is invalid", "email"),
+        ("Billing address not updating", "Every time I save a new billing address, the old one reappears — the update never persists", "web"),
+        // Other category (4 templates)
+        ("Feedback on the new UI", "I like the new dashboard design but the font size in the sidebar feels too small on 1080p", "web"),
+        ("Question about data retention policy", "How long does the system keep closed ticket records before archiving or deleting them?", "email"),
+        ("General inquiry about integrations", "Do you support integration with Zendesk or Freshdesk for bi-directional ticket sync?", "api"),
+        ("Suggestion for documentation", "The API documentation is missing examples for the bulk update endpoint — would help a lot", "web"),
+    ];
+
+    public static void MapSimulateEndpoints(this WebApplication app)
+    {
+        app.MapPost("/api/simulate", RunSimulation);
+    }
+
+    private static async Task<IResult> RunSimulation(
+        TicketDbContext db, PipelineService pipeline, int count = 10)
+    {
+        if (count < 1) count = 1;
+        if (count > 100) count = 100;
+
+        var autoResolved = 0;
+        var escalated = 0;
+        var byCategory = new Dictionary<string, int>();
+
+        var random = new Random();
+        for (var i = 0; i < count; i++)
+        {
+            var template = SampleTickets[random.Next(SampleTickets.Length)];
+            var result = await pipeline.ProcessTicket(
+                template.Title, template.Description, template.Source, db);
+
+            if (result.Ticket.Status == TicketDeflection.Models.TicketStatus.AutoResolved)
+                autoResolved++;
+            else
+                escalated++;
+
+            var cat = result.Category;
+            byCategory[cat] = byCategory.GetValueOrDefault(cat) + 1;
+        }
+
+        return Results.Ok(new SimulationSummary(count, autoResolved, escalated, byCategory));
+    }
+}
+
+public record SimulationSummary(int Generated, int AutoResolved, int Escalated, Dictionary<string, int> ByCategory);

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -23,6 +23,7 @@ using (var scope = app.Services.CreateScope())
 
 // --- Endpoint Mappings ---
 app.MapPipelineEndpoints();
+app.MapSimulateEndpoints();
 app.MapRazorPages();
 app.MapTicketEndpoints();
 app.MapKnowledgeEndpoints();


### PR DESCRIPTION
Closes #131

## Summary

Implements `POST /api/simulate` endpoint for generating realistic demo data by running tickets through the full pipeline.

## Changes

### `TicketDeflection/Endpoints/SimulateEndpoints.cs` (new)
- `MapSimulateEndpoints` extension method registered in `Program.cs`
- `POST /api/simulate` accepts optional `?count=N` (default: 10, max: 100)
- 24 distinct sample ticket templates covering all 5 categories (Bug, HowTo, FeatureRequest, AccountIssue, Other)
- Calls `PipelineService.ProcessTicket` for each ticket
- Returns `{ "generated": N, "autoResolved": N, "escalated": N, "byCategory": { ... } }`

### `TicketDeflection/Program.cs` (modified)
- Registered `MapSimulateEndpoints()` below the `// --- Endpoint Mappings ---` marker

### `TicketDeflection.Tests/SimulateEndpointTests.cs` (new)
- `Simulate_Count5_Returns5Generated` — calls `POST /api/simulate?count=5`, asserts `generated == 5` with correct structure
- `Simulate_DefaultCount_Returns10Generated` — asserts default is 10
- `Simulate_ExceedsMax_CappedAt100` — asserts count=200 is capped at 100

## Notes
NuGet package restore unavailable in agent environment (proxy restriction). Build and tests will run in GitHub Actions CI.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22508492759)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22508492759, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22508492759 -->

<!-- gh-aw-workflow-id: repo-assist -->