### PR TITLE
[Pipeline] Dashboard Overview Page with Metrics API

### DIFF
--- a/TicketDeflection.Tests/MetricsEndpointTests.cs
+++ b/TicketDeflection.Tests/MetricsEndpointTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using TicketDeflection.Data;
+
+namespace TicketDeflection.Tests;
+
+public class MetricsEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public MetricsEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(b =>
+            b.ConfigureServices(services =>
+            {
+                var existing = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<TicketDbContext>));
+                if (existing != null) services.Remove(existing);
+                services.AddDbContext<TicketDbContext>(o =>
+                    o.UseInMemoryDatabase($"MetricsTestDb_{Guid.NewGuid()}"));
+            }));
+    }
+
+    [Fact]
+    public async Task GetOverview_Returns200_WithExpectedStructure()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/metrics/overview");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        // Required fields exist
+        Assert.True(root.TryGetProperty("totalTickets", out _));
+        Assert.True(root.TryGetProperty("autoResolved", out _));
+        Assert.True(root.TryGetProperty("escalated", out _));
+        Assert.True(root.TryGetProperty("resolutionRate", out _));
+        Assert.True(root.TryGetProperty("byCategory", out _));
+        Assert.True(root.TryGetProperty("bySeverity", out _));
+    }
+
+    [Fact]
+    public async Task GetOverview_AfterSimulation_ReflectsTickets()
+    {
+        var client = _factory.CreateClient();
+
+        // Generate 10 tickets via the simulate endpoint
+        await client.PostAsync("/api/simulate?count=10", null);
+
+        var response = await client.GetAsync("/api/metrics/overview");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        var total = root.GetProperty("totalTickets").GetInt32();
+        Assert.Equal(10, total);
+
+        var autoResolved = root.GetProperty("autoResolved").GetInt32();
+        var escalated = root.GetProperty("escalated").GetInt32();
+        Assert.Equal(total, autoResolved + escalated);
+
+        var rate = root.GetProperty("resolutionRate").GetDouble();
+        Assert.InRange(rate, 0.0, 1.0);
+    }
+}

--- a/TicketDeflection/Endpoints/MetricsEndpoints.cs
+++ b/TicketDeflection/Endpoints/MetricsEndpoints.cs
@@ -1,0 +1,39 @@
+using TicketDeflection.Data;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Endpoints;
+
+public static class MetricsEndpoints
+{
+    public static void MapMetricsEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/metrics/overview", GetOverview);
+    }
+
+    private static IResult GetOverview(TicketDbContext db)
+    {
+        var tickets = db.Tickets.ToList();
+        var total = tickets.Count;
+        var autoResolved = tickets.Count(t => t.Status == TicketStatus.AutoResolved);
+        var escalated = tickets.Count(t => t.Status == TicketStatus.Escalated);
+        var resolutionRate = total > 0 ? (double)autoResolved / total : 0.0;
+
+        var byCategory = tickets
+            .GroupBy(t => t.Category.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var bySeverity = tickets
+            .GroupBy(t => t.Severity.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        return Results.Ok(new MetricsOverview(total, autoResolved, escalated, resolutionRate, byCategory, bySeverity));
+    }
+}
+
+public record MetricsOverview(
+    int TotalTickets,
+    int AutoResolved,
+    int Escalated,
+    double ResolutionRate,
+    Dictionary<string, int> ByCategory,
+    Dictionary<string, int> BySeverity);

--- a/TicketDeflection/Pages/Dashboard.cshtml
+++ b/TicketDeflection/Pages/Dashboard.cshtml
@@ -1,0 +1,95 @@
+@page "/dashboard"
+@model TicketDeflection.Pages.DashboardModel
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ticket Deflection Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-gray-100 min-h-screen p-6">
+    <div class="max-w-5xl mx-auto">
+        <div class="flex items-center justify-between mb-6">
+            <h1 class="text-3xl font-bold text-gray-800">Ticket Deflection Dashboard</h1>
+            <button id="refreshBtn"
+                    onclick="loadMetrics()"
+                    class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">
+                Refresh
+            </button>
+        </div>
+
+        <!-- KPI Cards -->
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+            <div class="bg-white rounded-lg shadow p-4">
+                <p class="text-sm text-gray-500">Total Tickets</p>
+                <p id="totalTickets" class="text-2xl font-bold text-gray-800">—</p>
+            </div>
+            <div class="bg-white rounded-lg shadow p-4">
+                <p class="text-sm text-gray-500">Auto-Resolved</p>
+                <p id="autoResolved" class="text-2xl font-bold text-green-600">—</p>
+            </div>
+            <div class="bg-white rounded-lg shadow p-4">
+                <p class="text-sm text-gray-500">Escalated</p>
+                <p id="escalated" class="text-2xl font-bold text-red-500">—</p>
+            </div>
+            <div class="bg-white rounded-lg shadow p-4">
+                <p class="text-sm text-gray-500">Resolution Rate</p>
+                <p id="resolutionRate" class="text-2xl font-bold text-blue-600">—</p>
+            </div>
+        </div>
+
+        <!-- Charts -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="bg-white rounded-lg shadow p-4">
+                <h2 class="text-lg font-semibold text-gray-700 mb-3">By Category</h2>
+                <canvas id="categoryChart"></canvas>
+            </div>
+            <div class="bg-white rounded-lg shadow p-4">
+                <h2 class="text-lg font-semibold text-gray-700 mb-3">By Severity</h2>
+                <canvas id="severityChart"></canvas>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let categoryChart, severityChart;
+
+        async function loadMetrics() {
+            const res = await fetch('/api/metrics/overview');
+            if (!res.ok) return;
+            const data = await res.json();
+
+            document.getElementById('totalTickets').textContent = data.totalTickets;
+            document.getElementById('autoResolved').textContent = data.autoResolved;
+            document.getElementById('escalated').textContent = data.escalated;
+            document.getElementById('resolutionRate').textContent =
+                (data.resolutionRate * 100).toFixed(1) + '%';
+
+            renderChart('categoryChart', categoryChart, data.byCategory, (c) => categoryChart = c);
+            renderChart('severityChart', severityChart, data.bySeverity, (c) => severityChart = c);
+        }
+
+        function renderChart(canvasId, existing, dataObj, setChart) {
+            const labels = Object.keys(dataObj);
+            const values = Object.values(dataObj);
+            if (existing) existing.destroy();
+            const chart = new Chart(document.getElementById(canvasId), {
+                type: 'doughnut',
+                data: {
+                    labels,
+                    datasets: [{ data: values, borderWidth: 1 }]
+                },
+                options: { responsive: true }
+            });
+            setChart(chart);
+        }
+
+        loadMetrics();
+    </script>
+</body>
+</html>

--- a/TicketDeflection/Pages/Dashboard.cshtml.cs
+++ b/TicketDeflection/Pages/Dashboard.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TicketDeflection.Pages;
+
+public class DashboardModel : PageModel
+{
+    public void OnGet() { }
+}

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -23,6 +23,7 @@ using (var scope = app.Services.CreateScope())
 
 // --- Endpoint Mappings ---
 app.MapPipelineEndpoints();
+app.MapMetricsEndpoints();
 app.MapRazorPages();
 app.MapTicketEndpoints();
 app.MapKnowledgeEndpoints();


### PR DESCRIPTION
Closes #132

## Summary

Adds `GET /api/metrics/overview` endpoint and `/dashboard` Razor Page with Chart.js visualizations.

## Changes

### `TicketDeflection/Endpoints/MetricsEndpoints.cs` (new)
- `MapMetricsEndpoints` extension method registered in `Program.cs`
- `GET /api/metrics/overview` returns: `totalTickets`, `autoResolved`, `escalated`, `resolutionRate` (0.0–1.0), `byCategory`, `bySeverity`

### `TicketDeflection/Pages/Dashboard.cshtml` (new)
- `@page "/dashboard"` directive
- Loads Tailwind CSS from CDN (`cdn.tailwindcss.com`)
- Loads Chart.js from CDN (`cdn.jsdelivr.net/npm/chart.js`)
- `(canvas id="categoryChart")` and `(canvas id="severityChart")` elements
- Resolution rate KPI card (`id="resolutionRate"`)
- Refresh button that calls `loadMetrics()`
- JavaScript fetches `GET /api/metrics/overview` on load and renders doughnut charts

### `TicketDeflection/Pages/Dashboard.cshtml.cs` (new)
- Minimal `DashboardModel : PageModel` class

### `TicketDeflection/Program.cs` (modified)
- Registered `MapMetricsEndpoints()` below the `// --- Endpoint Mappings ---` marker

### `TicketDeflection.Tests/MetricsEndpointTests.cs` (new)
- `GetOverview_Returns200_WithExpectedStructure` — verifies 200 + all required fields
- `GetOverview_AfterSimulation_ReflectsTickets` — runs simulation then verifies metrics totals

## Notes
NuGet package restore unavailable in agent environment (proxy restriction). Build and tests will run in GitHub Actions CI.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22508492759)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22508492759, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22508492759 -->

<!-- gh-aw-workflow-id: repo-assist -->