### PR TITLE
[Pipeline] Dashboard Ticket Feed Razor Page

### DIFF
--- a/TicketDeflection.Tests/TicketFeedEndpointTests.cs
+++ b/TicketDeflection.Tests/TicketFeedEndpointTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Text.Json;
+using TicketDeflection.Data;
+
+namespace TicketDeflection.Tests;
+
+public class TicketFeedEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public TicketFeedEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(b =>
+            b.ConfigureServices(services =>
+            {
+                var existing = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<TicketDbContext>));
+                if (existing != null) services.Remove(existing);
+                services.AddDbContext<TicketDbContext>(o =>
+                    o.UseInMemoryDatabase($"TicketFeedTestDb_{Guid.NewGuid()}"));
+            }));
+    }
+
+    [Fact]
+    public async Task GetTickets_Returns200_WithExpectedStructure()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/metrics/tickets");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task GetTickets_EmptyDb_ReturnsEmptyArray()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/metrics/tickets");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(0, doc.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task GetTickets_RespectsLimitParameter()
+    {
+        var client = _factory.CreateClient();
+
+        // Create some tickets via simulation
+        await client.PostAsync("/api/simulate?count=10", null);
+
+        var response = await client.GetAsync("/api/metrics/tickets?limit=5&offset=0");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.True(doc.RootElement.GetArrayLength() <= 5);
+    }
+
+    [Fact]
+    public async Task GetTickets_EachItemHasExpectedFields()
+    {
+        var client = _factory.CreateClient();
+
+        await client.PostAsync("/api/simulate?count=3", null);
+
+        var response = await client.GetAsync("/api/metrics/tickets?limit=3");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var arr = doc.RootElement;
+
+        if (arr.GetArrayLength() > 0)
+        {
+            var first = arr[0];
+            Assert.True(first.TryGetProperty("id", out _), "Missing id");
+            Assert.True(first.TryGetProperty("title", out _), "Missing title");
+            Assert.True(first.TryGetProperty("category", out _), "Missing category");
+            Assert.True(first.TryGetProperty("severity", out _), "Missing severity");
+            Assert.True(first.TryGetProperty("status", out _), "Missing status");
+            Assert.True(first.TryGetProperty("source", out _), "Missing source");
+            Assert.True(first.TryGetProperty("createdAt", out _), "Missing createdAt");
+        }
+    }
+}

--- a/TicketDeflection/Endpoints/MetricsEndpoints.cs
+++ b/TicketDeflection/Endpoints/MetricsEndpoints.cs
@@ -9,6 +9,7 @@ public static class MetricsEndpoints
     public static void MapMetricsEndpoints(this WebApplication app)
     {
         app.MapGet("/api/metrics/overview", GetOverview);
+        app.MapGet("/api/metrics/tickets", GetTickets);
     }
 
     private static async Task<IResult> GetOverview(TicketDbContext db)
@@ -30,6 +31,20 @@ public static class MetricsEndpoints
 
         return Results.Ok(new MetricsOverview(total, autoResolved, escalated, resolutionRate, byCategory, bySeverity));
     }
+
+    private static async Task<IResult> GetTickets(TicketDbContext db, int limit = 20, int offset = 0)
+    {
+        var tickets = await db.Tickets
+            .OrderByDescending(t => t.CreatedAt)
+            .Skip(offset)
+            .Take(limit)
+            .Select(t => new TicketSummary(
+                t.Id, t.Title, t.Category.ToString(), t.Severity.ToString(),
+                t.Status.ToString(), t.Source, t.CreatedAt, t.Resolution))
+            .ToListAsync();
+
+        return Results.Ok(tickets);
+    }
 }
 
 public record MetricsOverview(
@@ -39,3 +54,13 @@ public record MetricsOverview(
     double ResolutionRate,
     Dictionary<string, int> ByCategory,
     Dictionary<string, int> BySeverity);
+
+public record TicketSummary(
+    Guid Id,
+    string Title,
+    string Category,
+    string Severity,
+    string Status,
+    string Source,
+    DateTime CreatedAt,
+    string? Resolution);

--- a/TicketDeflection/Pages/Tickets.cshtml
+++ b/TicketDeflection/Pages/Tickets.cshtml
@@ -1,0 +1,80 @@
+@page "/tickets"
+@model TicketsModel
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ticket Feed</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen p-6">
+    <div class="max-w-5xl mx-auto">
+        <div class="flex items-center justify-between mb-6">
+            <h1 class="text-3xl font-bold text-gray-800">Ticket Feed</h1>
+            <div class="flex gap-2">
+                <a href="/dashboard" class="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition">Dashboard</a>
+                <button onclick="loadTickets()" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">Refresh</button>
+            </div>
+        </div>
+
+        <div id="ticket-feed" class="space-y-3">
+            <p class="text-gray-500">Loading...</p>
+        </div>
+
+        <div class="flex gap-2 mt-4">
+            <button id="prevBtn" onclick="prevPage()" disabled
+                    class="px-4 py-2 bg-gray-200 rounded disabled:opacity-50">Previous</button>
+            <button id="nextBtn" onclick="nextPage()"
+                    class="px-4 py-2 bg-gray-200 rounded disabled:opacity-50">Next</button>
+        </div>
+    </div>
+
+    <script>
+        const LIMIT = 20;
+        let offset = 0;
+
+        const statusBadge = {
+            AutoResolved: 'bg-green-100 text-green-800',
+            Escalated: 'bg-red-100 text-red-800',
+            New: 'bg-gray-100 text-gray-800',
+            Classified: 'bg-blue-100 text-blue-800',
+            Matched: 'bg-yellow-100 text-yellow-800'
+        };
+
+        async function loadTickets() {
+            const res = await fetch(`/api/metrics/tickets?limit=${LIMIT}&offset=${offset}`);
+            const tickets = await res.json();
+            const feed = document.getElementById('ticket-feed');
+
+            if (tickets.length === 0) {
+                feed.innerHTML = '<p class="text-gray-500">No tickets found.</p>';
+                document.getElementById('nextBtn').disabled = true;
+                return;
+            }
+
+            feed.innerHTML = tickets.map(t => {
+                const badge = statusBadge[t.status] || 'bg-gray-100 text-gray-800';
+                const date = new Date(t.createdAt).toLocaleString();
+                return `
+                <div class="bg-white rounded-lg shadow p-4 flex items-start justify-between gap-4">
+                    <div class="flex-1 min-w-0">
+                        <p class="font-semibold text-gray-800 truncate">${t.title}</p>
+                        <p class="text-sm text-gray-500">${t.category} · ${t.severity} · ${date}</p>
+                        ${t.resolution ? `<p class="text-sm text-gray-600 mt-1 italic">${t.resolution}</p>` : ''}
+                    </div>
+                    <span class="text-xs font-medium px-2 py-1 rounded-full whitespace-nowrap ${badge}">${t.status}</span>
+                </div>`;
+            }).join('');
+
+            document.getElementById('prevBtn').disabled = offset === 0;
+            document.getElementById('nextBtn').disabled = tickets.length < LIMIT;
+        }
+
+        function prevPage() { offset = Math.max(0, offset - LIMIT); loadTickets(); }
+        function nextPage() { offset += LIMIT; loadTickets(); }
+
+        loadTickets();
+    </script>
+</body>
+</html>

--- a/TicketDeflection/Pages/Tickets.cshtml.cs
+++ b/TicketDeflection/Pages/Tickets.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TicketDeflection.Pages;
+
+public class TicketsModel : PageModel
+{
+}


### PR DESCRIPTION
Closes #133

## Summary

Implements the Dashboard Ticket Feed Razor Page as specified in issue #133.

## Changes

### `TicketDeflection/Endpoints/MetricsEndpoints.cs` (modified)
- Added `GET /api/metrics/tickets` endpoint with `?limit=20&offset=0` pagination
- Added `TicketSummary` record type: `id`, `title`, `category`, `severity`, `status`, `source`, `createdAt`, `resolution`
- Tickets sorted by `CreatedAt` descending

### `TicketDeflection/Pages/Tickets.cshtml` (new)
- `@page "/tickets"` directive
- Tailwind CSS loaded from CDN
- `(div id="ticket-feed")` container for rendered ticket list
- Status-coded badges: AutoResolved=green, Escalated=red, New/other=gray/blue
- JavaScript fetches `GET /api/metrics/tickets` on load and renders paginated list
- Previous/Next pagination buttons

### `TicketDeflection/Pages/Tickets.cshtml.cs` (new)
- Minimal `TicketsModel : PageModel` class

### `TicketDeflection.Tests/TicketFeedEndpointTests.cs` (new)
- `GetTickets_Returns200_WithExpectedStructure` — verifies 200 + JSON array response
- `GetTickets_EmptyDb_ReturnsEmptyArray` — verifies empty array on empty database
- `GetTickets_RespectsLimitParameter` — verifies `?limit=5` returns ≤5 items
- `GetTickets_EachItemHasExpectedFields` — verifies all required fields present

## Notes
NuGet package restore is unavailable in the agent environment (proxy restriction). Build and tests will run in GitHub Actions CI.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22509139664)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22509139664, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22509139664 -->

<!-- gh-aw-workflow-id: repo-assist -->