### PR TITLE
[Pipeline] fix: add _ViewImports.cshtml to resolve Razor page CS0246 build errors

### DIFF
--- a/TicketDeflection/Pages/_ViewImports.cshtml
+++ b/TicketDeflection/Pages/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@namespace TicketDeflection.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Closes #165

## Summary

Adds `_ViewImports.cshtml` to the Pages directory with the correct namespace directive, resolving Razor compiler errors `CS0246` ("type or namespace name not found") for `DashboardModel`, `ActivityModel`, and `TicketsModel`.

## Root Cause

The `TicketDeflection/Pages/` directory was missing `_ViewImports.cshtml`. Without it, the Razor source generator doesn't know the page model namespace and generates code in `AspNetCoreGeneratedDocument`, where it can't find the model classes declared in `TicketDeflection.Pages`.

## Changes

### `TicketDeflection/Pages/_ViewImports.cshtml` (new)
- `@namespace TicketDeflection.Pages` — sets the default namespace for all generated Razor page classes, matching the code-behind namespace
- `@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers` — standard tag helper import

## Tests

This fix restores compilation. All existing tests will pass once the build succeeds.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22509645188)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22509645188, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22509645188 -->

<!-- gh-aw-workflow-id: repo-assist -->