### PR TITLE
[Pipeline] Fix CS0117 build error: add CreatedAt to KnowledgeArticle model

### DIFF
--- a/TicketDeflection/Models/KnowledgeArticle.cs
+++ b/TicketDeflection/Models/KnowledgeArticle.cs
@@ -7,4 +7,5 @@ public class KnowledgeArticle
     public string Content { get; set; } = string.Empty;
     public string Tags { get; set; } = string.Empty;
     public TicketCategory Category { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }


### PR DESCRIPTION
Closes #172

## Summary

Fixes the `CS0117` build error where `KnowledgeEndpoints.cs` references `KnowledgeArticle.CreatedAt` but the property was missing from the model class.

## Changes

### `TicketDeflection/Models/KnowledgeArticle.cs`
- Added `public DateTime CreatedAt { get; set; } = DateTime.UtcNow;`

## Root Cause

`KnowledgeEndpoints.cs` line 34 assigns `CreatedAt = DateTime.UtcNow` when creating a `KnowledgeArticle`, but the model was defined without this property. This caused the `dotnet build` to fail with:

```
error CS0117: 'KnowledgeArticle' does not contain a definition for 'CreatedAt'
```

## Testing

This is a one-line model fix. The CI build and test suite will verify the fix once the proxy allows NuGet restoration.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22510486779)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22510486779, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22510486779 -->

<!-- gh-aw-workflow-id: repo-assist -->