### PR TITLE
[Pipeline] Update target framework from net8.0 to net10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY TicketDeflection/TicketDeflection.csproj TicketDeflection/
 COPY TicketDeflection.Tests/TicketDeflection.Tests.csproj TicketDeflection.Tests/
@@ -6,7 +6,7 @@ RUN dotnet restore TicketDeflection/TicketDeflection.csproj
 COPY . .
 RUN dotnet publish TicketDeflection/TicketDeflection.csproj -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/publish .
 EXPOSE 8080

--- a/TicketDeflection.Tests/TicketDeflection.Tests.csproj
+++ b/TicketDeflection.Tests/TicketDeflection.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/TicketDeflection/TicketDeflection.csproj
+++ b/TicketDeflection/TicketDeflection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.418",
+    "version": "10.0.102",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
Closes #176

## Summary

Upgrades the project from .NET 8 to .NET 10 to match the CI runner and local development environment.

## Changes

| File | Change |
|------|--------|
| `global.json` | SDK version `8.0.418` → `10.0.102`, `rollForward: latestPatch` |
| `TicketDeflection/TicketDeflection.csproj` | `TargetFramework: net8.0` → `net10.0` |
| `TicketDeflection.Tests/TicketDeflection.Tests.csproj` | `TargetFramework: net8.0` → `net10.0` |
| `Dockerfile` | Base images `dotnet/sdk:8.0` / `dotnet/aspnet:8.0` → `dotnet/sdk:10.0` / `dotnet/aspnet:10.0` |

## Test Results

Build and test could not run locally due to NuGet proxy restrictions in the agent environment (`api.nuget.org` blocked). The changes are purely target framework version updates with no code modifications — CI should validate correctness.

> ⚠️ This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22511434911)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `api.nuget.org`
>
> </details>


<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22511434911, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22511434911 -->

<!-- gh-aw-workflow-id: repo-assist -->