### PR TITLE
[Pipeline] Upgrade NuGet packages to .NET 9.0.x for net10.0 compatibility

### DIFF
--- a/TicketDeflection.Tests/TicketDeflection.Tests.csproj
+++ b/TicketDeflection.Tests/TicketDeflection.Tests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TicketDeflection/TicketDeflection.csproj
+++ b/TicketDeflection/TicketDeflection.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #185

## Summary

Upgrades all NuGet packages to versions compatible with the `net10.0` target framework set in PR #182. The old .NET 8.x packages caused runtime incompatibilities (33/62 tests failing with `InternalServerError`).

## Changes

| Package | Old Version | New Version |
|---------|-------------|-------------|
| `Microsoft.EntityFrameworkCore.InMemory` | 8.0.0 | 9.0.2 |
| `Microsoft.AspNetCore.Mvc.Testing` | 8.0.0 | 9.0.2 |
| `Microsoft.NET.Test.Sdk` | 17.8.0 | 17.12.0 |
| `xunit` | 2.5.3 | 2.9.2 |
| `xunit.runner.visualstudio` | 2.5.3 | 2.8.2 |
| `coverlet.collector` | 6.0.0 | 6.0.2 |

EF Core 9.0.x and `Microsoft.AspNetCore.Mvc.Testing` 9.0.x are compatible with `net10.0` target framework (NuGet TFM compatibility rules allow net9.0 packages in net10.0 projects). The test infrastructure packages (`Microsoft.NET.Test.Sdk`, `xunit`) are updated to current stable releases.

Upgrading to 9.0.x also removes the `NU1903` high-severity vulnerability in the `Microsoft.Extensions.Caching.Memory` 8.0.0 transitive dependency.

## Test Results

Build and test cannot run locally due to NuGet proxy restrictions in the agent environment (`api.nuget.org` blocked). CI will validate correctness.

> ⚠️ This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22511842263)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `api.nuget.org`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "api.nuget.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22511842263, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22511842263 -->

<!-- gh-aw-workflow-id: repo-assist -->