### PR TITLE
[Pipeline] Auto-seed 25 demo tickets on startup for cold-start dashboard

### DIFF
--- a/TicketDeflection.Tests/ActivityEndpointTests.cs
+++ b/TicketDeflection.Tests/ActivityEndpointTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http.Json;
@@ -17,13 +18,17 @@ public class ActivityEndpointTests : IClassFixture<WebApplicationFactory<Program
     {
         var dbName = $"ActivityTestDb_{Guid.NewGuid()}";
         _factory = factory.WithWebHostBuilder(b =>
+        {
+            b.ConfigureAppConfiguration((_, config) =>
+                config.AddInMemoryCollection(new Dictionary<string, string?> { ["DemoSeed:Enabled"] = "false" }));
             b.ConfigureServices(services =>
             {
                 var existing = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<TicketDbContext>));
                 if (existing != null) services.Remove(existing);
                 services.AddDbContext<TicketDbContext>(o =>
                     o.UseInMemoryDatabase(dbName));
-            }));
+            });
+        });
     }
 
     [Fact]

--- a/TicketDeflection.Tests/MetricsEndpointTests.cs
+++ b/TicketDeflection.Tests/MetricsEndpointTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http.Json;
@@ -16,13 +17,17 @@ public class MetricsEndpointTests : IClassFixture<WebApplicationFactory<Program>
     {
         var dbName = $"MetricsTestDb_{Guid.NewGuid()}";
         _factory = factory.WithWebHostBuilder(b =>
+        {
+            b.ConfigureAppConfiguration((_, config) =>
+                config.AddInMemoryCollection(new Dictionary<string, string?> { ["DemoSeed:Enabled"] = "false" }));
             b.ConfigureServices(services =>
             {
                 var existing = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<TicketDbContext>));
                 if (existing != null) services.Remove(existing);
                 services.AddDbContext<TicketDbContext>(o =>
                     o.UseInMemoryDatabase(dbName));
-            }));
+            });
+        });
     }
 
     [Fact]

--- a/TicketDeflection.Tests/TicketFeedEndpointTests.cs
+++ b/TicketDeflection.Tests/TicketFeedEndpointTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Text.Json;
@@ -15,13 +16,17 @@ public class TicketFeedEndpointTests : IClassFixture<WebApplicationFactory<Progr
     {
         var dbName = $"TicketFeedTestDb_{Guid.NewGuid()}";
         _factory = factory.WithWebHostBuilder(b =>
+        {
+            b.ConfigureAppConfiguration((_, config) =>
+                config.AddInMemoryCollection(new Dictionary<string, string?> { ["DemoSeed:Enabled"] = "false" }));
             b.ConfigureServices(services =>
             {
                 var existing = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<TicketDbContext>));
                 if (existing != null) services.Remove(existing);
                 services.AddDbContext<TicketDbContext>(o =>
                     o.UseInMemoryDatabase(dbName));
-            }));
+            });
+        });
     }
 
     [Fact]

--- a/TicketDeflection/Endpoints/SimulateEndpoints.cs
+++ b/TicketDeflection/Endpoints/SimulateEndpoints.cs
@@ -5,7 +5,7 @@ namespace TicketDeflection.Endpoints;
 
 public static class SimulateEndpoints
 {
-    private static readonly (string Title, string Description, string Source)[] SampleTickets =
+    internal static readonly (string Title, string Description, string Source)[] SampleTickets =
     [
         // Bug category (5 templates)
         ("Application crashes on login", "The app throws a NullReferenceException when I try to log in with my Google account", "web"),

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -14,11 +14,22 @@ builder.Services.AddRazorPages();
 
 var app = builder.Build();
 
-// Seed knowledge base on startup
+// Seed knowledge base and auto-populate demo tickets on startup
 using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<TicketDbContext>();
     SeedData.Initialize(context);
+
+    if (app.Configuration.GetValue<bool>("DemoSeed:Enabled", true) && !context.Tickets.Any())
+    {
+        var pipeline = scope.ServiceProvider.GetRequiredService<PipelineService>();
+        var random = new Random(42);
+        for (var i = 0; i < 25; i++)
+        {
+            var template = SimulateEndpoints.SampleTickets[random.Next(SimulateEndpoints.SampleTickets.Length)];
+            await pipeline.ProcessTicket(template.Title, template.Description, template.Source, context);
+        }
+    }
 }
 
 // --- Endpoint Mappings ---


### PR DESCRIPTION
Closes #190

## Summary

On cold start, the dashboard showed an empty state (0 tickets, 0% resolution rate). This PR auto-seeds 25 demo tickets through the full pipeline on app startup so the dashboard is populated from the first request.

## Changes

- **`TicketDeflection/Endpoints/SimulateEndpoints.cs`**: Changed `SampleTickets` from `private` to `internal` so `Program.cs` can reference it
- **`TicketDeflection/Program.cs`**: After seeding the knowledge base, checks if any tickets exist. If not, runs 25 sample tickets through `PipelineService.ProcessTicket()` using a fixed random seed (42) for deterministic demo data. Reads `DemoSeed:Enabled` config flag (default `true`) to allow tests to opt out
- **`TicketDeflection.Tests/ActivityEndpointTests.cs`**: Set `DemoSeed:Enabled=false` in test factory to preserve test isolation
- **`TicketDeflection.Tests/MetricsEndpointTests.cs`**: Set `DemoSeed:Enabled=false` in test factory
- **`TicketDeflection.Tests/TicketFeedEndpointTests.cs`**: Set `DemoSeed:Enabled=false` in test factory

## Test Results

```
Passed!  - Failed: 0, Passed: 62, Skipped: 0, Total: 62
```

All 62 tests pass.

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22512485596) for issue #190

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22512485596, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22512485596 -->

<!-- gh-aw-workflow-id: repo-assist -->