### PR TITLE
[Pipeline] Redirect Run Demo button to /dashboard after simulation

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -55,26 +55,26 @@
     <script>
         async function runDemo() {
             const btn = document.getElementById('runDemoBtn');
-            const results = document.getElementById('demoResults');
-            const resultsContent = document.getElementById('demoResultsContent');
             const errorDiv = document.getElementById('demoError');
             const errorContent = document.getElementById('demoErrorContent');
 
             btn.disabled = true;
             btn.textContent = 'Running…';
-            results.classList.add('hidden');
             errorDiv.classList.add('hidden');
 
             try {
                 const response = await fetch('/api/simulate?count=25', { method: 'POST' });
-                if (!response.ok) throw new Error(`HTTP ${response.status}`);
-                const data = await response.json();
-                resultsContent.textContent = JSON.stringify(data, null, 2);
-                results.classList.remove('hidden');
+                if (response.ok) {
+                    window.location.href = '/dashboard';
+                } else {
+                    errorContent.textContent = 'Simulation failed. Please try again.';
+                    errorDiv.classList.remove('hidden');
+                    btn.disabled = false;
+                    btn.textContent = 'Run Demo';
+                }
             } catch (err) {
                 errorContent.textContent = `Demo failed: ${err.message}`;
                 errorDiv.classList.remove('hidden');
-            } finally {
                 btn.disabled = false;
                 btn.textContent = 'Run Demo';
             }


### PR DESCRIPTION
Closes #191

## Summary

After clicking "Run Demo" on the landing page, the app now redirects to `/dashboard` on success instead of showing raw JSON output. This closes the demo loop: one click → simulation runs → dashboard shows populated metrics.

## Changes

- **`TicketDeflection/Pages/Index.cshtml`**: Updated `runDemo()` JavaScript function:
  - On `response.ok`: redirect to `/dashboard` via `window.location.href`
  - On non-ok response: show inline error message, re-enable button
  - On network error: show inline error message, re-enable button
  - Removed the `demoResults`/`demoResultsContent` DOM manipulation (no longer needed)

## Test Results

```
Passed!  - Failed: 0, Passed: 62, Skipped: 0, Total: 62
```

All 62 tests pass. No `.github/workflows/` files modified.

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22512485596) for issue #190

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22512485596, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22512485596 -->

<!-- gh-aw-workflow-id: repo-assist -->