### PR TITLE
[Pipeline] Fix Tokenize punctuation stripping in MatchingService and PipelineService

### DIFF
--- a/TicketDeflection/Services/MatchingService.cs
+++ b/TicketDeflection/Services/MatchingService.cs
@@ -47,9 +47,13 @@ public class MatchingService
         }
     }
 
+    private static readonly char[] _punctuation =
+        ['.', '!', '?', ';', ':', '\'', '"', '(', ')', '[', ']', '{', '}', '<', '>', '/'];
+
     private static HashSet<string> Tokenize(string text) =>
         text.Split([' ', '\t', ',', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
-            .Select(t => t.ToLowerInvariant())
+            .Select(t => t.Trim(_punctuation).ToLowerInvariant())
+            .Where(t => t.Length > 0)
             .ToHashSet();
 
     private static double Jaccard(HashSet<string> a, HashSet<string> b)

--- a/TicketDeflection/Services/PipelineService.cs
+++ b/TicketDeflection/Services/PipelineService.cs
@@ -86,9 +86,13 @@ public class PipelineService
         Details = details
     };
 
+    private static readonly char[] _punctuation =
+        ['.', '!', '?', ';', ':', '\'', '"', '(', ')', '[', ']', '{', '}', '<', '>', '/'];
+
     private static HashSet<string> Tokenize(string text) =>
         text.Split([' ', '\t', ',', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
-            .Select(t => t.ToLowerInvariant())
+            .Select(t => t.Trim(_punctuation).ToLowerInvariant())
+            .Where(t => t.Length > 0)
             .ToHashSet();
 
     private static double Jaccard(HashSet<string> a, HashSet<string> b)


### PR DESCRIPTION
Fixes the 0% deflection rate caused by punctuation characters attached to word boundaries preventing token matches.

## Changes

Both `Tokenize` methods in `MatchingService.cs` and `PipelineService.cs` now strip leading/trailing punctuation from each token using `.Trim(_punctuation)`:

```csharp
private static readonly char[] _punctuation =
    ['.', '!', '?', ';', ':', '\'', '"', '(', ')', '[', ']', '{', '}', '<', '>', '/'];

private static HashSet(string) Tokenize(string text) =>
    text.Split([' ', '\t', ',', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
        .Select(t => t.Trim(_punctuation).ToLowerInvariant())
        .Where(t => t.Length > 0)
        .ToHashSet();
```

## Root Cause

Knowledge article content contains punctuation at token boundaries, e.g.:
- `'Forgot` and `Password'` (from `'Forgot Password'` in the seed content)
- `inbox.`, `details.`, `access.` (sentence-ending periods)

These tokens failed to match the equivalent words in ticket text, reducing Jaccard similarity below the 0.3 threshold and causing all tickets to escalate.

## Test Results

All 62 tests pass: `Failed: 0, Passed: 62, Skipped: 0`

---
*This PR was created by Pipeline Assistant.*

- Fixes #195




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22512778151) for issue #195

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22512778151, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22512778151 -->

<!-- gh-aw-workflow-id: repo-assist -->