### PR TITLE
[Pipeline] Fix demo button: add 30s timeout to prevent indefinite executing... state

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -470,6 +470,8 @@
     </div>
 
     <script>
+        const DEMO_TIMEOUT_MS = 30000;
+
         async function runDemo() {
             const btn = document.getElementById('runDemoBtn');
             const btnText = document.getElementById('btnText');
@@ -482,23 +484,35 @@
             btnLoading.classList.remove('hidden');
             errorDiv.classList.add('hidden');
 
-            try {
-                const response = await fetch('/api/simulate?count=25', { method: 'POST' });
-                if (response.ok) {
-                    window.location.href = '/dashboard';
-                } else {
-                    errorContent.textContent = 'Simulation failed. Please try again.';
-                    errorDiv.classList.remove('hidden');
-                    btn.disabled = false;
-                    btnText.classList.remove('hidden');
-                    btnLoading.classList.add('hidden');
-                }
-            } catch (err) {
-                errorContent.textContent = err.message;
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), DEMO_TIMEOUT_MS);
+
+            function recover(msg) {
+                clearTimeout(timeoutId);
+                errorContent.textContent = msg;
                 errorDiv.classList.remove('hidden');
                 btn.disabled = false;
                 btnText.classList.remove('hidden');
                 btnLoading.classList.add('hidden');
+            }
+
+            try {
+                const response = await fetch('/api/simulate?count=25', {
+                    method: 'POST',
+                    signal: controller.signal
+                });
+                clearTimeout(timeoutId);
+                if (response.ok) {
+                    window.location.href = '/dashboard';
+                } else {
+                    recover('Simulation failed (HTTP ' + response.status + '). Please try again.');
+                }
+            } catch (err) {
+                if (err.name === 'AbortError') {
+                    recover('Request timed out after 30 s. The server may be cold-starting — please try again.');
+                } else {
+                    recover(err.message || 'Network error. Please try again.');
+                }
             }
         }
     </script>


### PR DESCRIPTION
Closes #209

## Summary

Adds a 30-second `AbortController` timeout to the "Run Demo" button's `fetch` call on the landing page. Previously, if the server was slow or the network stalled, the button would stay in an `executing...` state indefinitely with no way to recover short of a page refresh.

## Changes

- `TicketDeflection/Pages/Index.cshtml`: Rewrote `runDemo()` to use `AbortController` with a 30s timeout. Added a shared `recover()` helper to avoid code duplication in the three error paths.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Request times out | Button stuck forever | Button recovers; message: "Request timed out after 30 s. The server may be cold-starting — please try again." |
| HTTP error (non-2xx) | "Simulation failed" (no code) | "Simulation failed (HTTP 5xx). Please try again." |
| Network error | `err.message` or blank | `err.message` with `'Network error'` fallback |
| Normal fast path | Redirect to /dashboard | Unchanged |

## Test Results

```
Passed! - Failed: 0, Passed: 62, Skipped: 0, Total: 62
```

Build succeeds with 0 errors.

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514192430)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22514192430, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514192430 -->

<!-- gh-aw-workflow-id: repo-assist -->