### PR TITLE
[Pipeline] Fix dashboard charts: constrain doughnut charts to 240px height

### DIFF
--- a/TicketDeflection/Pages/Dashboard.cshtml
+++ b/TicketDeflection/Pages/Dashboard.cshtml
@@ -152,11 +152,15 @@
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div class="chart-panel">
                 <div class="chart-label">// distribution by category</div>
-                <canvas id="categoryChart"></canvas>
+                <div style="position: relative; height: 240px;">
+                    <canvas id="categoryChart"></canvas>
+                </div>
             </div>
             <div class="chart-panel">
                 <div class="chart-label">// distribution by severity</div>
-                <canvas id="severityChart"></canvas>
+                <div style="position: relative; height: 240px;">
+                    <canvas id="severityChart"></canvas>
+                </div>
             </div>
         </div>
 
@@ -204,12 +208,26 @@
                         data: values,
                         backgroundColor: CHART_COLORS.slice(0, values.length),
                         borderColor: '#080c12',
-                        borderWidth: 2
+                        borderWidth: 2,
+                        hoverBorderColor: 'rgba(0,170,255,0.4)'
                     }]
                 },
                 options: {
-                    ...chartDefaults,
-                    cutout: '60%'
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    cutout: '60%',
+                    plugins: {
+                        legend: {
+                            position: 'bottom',
+                            labels: {
+                                color: '#b8c4d4',
+                                font: { family: "'JetBrains Mono', monospace", size: 10 },
+                                padding: 12,
+                                boxWidth: 10,
+                                boxHeight: 10
+                            }
+                        }
+                    }
                 }
             });
 


### PR DESCRIPTION
Closes #210

## Summary

Fixes the oversized doughnut charts on the Dashboard page. Previously the `(canvas)` elements had no height constraint, causing Chart.js to expand them to fill the viewport. Now each chart is contained in a fixed 240px wrapper and correctly fills that space.

## Changes

- `TicketDeflection/Pages/Dashboard.cshtml`:
  - Wrapped each `(canvas)` in `(div style="position: relative; height: 240px;")` — the correct Chart.js pattern for explicit sizing
  - Added `responsive: true, maintainAspectRatio: false` to chart options so Chart.js fills the fixed container instead of expanding
  - Moved legend to `position: 'bottom'` to reclaim vertical space
  - Themed legend labels: JetBrains Mono, `--text` colour, compact 10px font, 10px box — consistent with Blueprint×Terminal aesthetic
  - Added `hoverBorderColor` using `--accent` tint for subtle interactivity

## Test Results

```
Passed! - Failed: 0, Passed: 62, Skipped: 0, Total: 62
```

Build succeeds with 0 errors.

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514192430)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22514192430, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514192430 -->

<!-- gh-aw-workflow-id: repo-assist -->