### PR TITLE
[Pipeline] Add OpenGraph meta tags and SVG favicon for social sharing

### DIFF
--- a/TicketDeflection/Pages/Activity.cshtml
+++ b/TicketDeflection/Pages/Activity.cshtml
@@ -6,6 +6,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Activity Log — prd-to-prod</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com"></script>
     <style>

--- a/TicketDeflection/Pages/Dashboard.cshtml
+++ b/TicketDeflection/Pages/Dashboard.cshtml
@@ -6,6 +6,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard — prd-to-prod</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -6,6 +6,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>prd-to-prod — autonomous software pipeline</title>
+    <meta name="description" content="Drop a PRD, get a deployed app. Zero human code. An autonomous GitHub pipeline that decomposes requirements, writes code, reviews its own work, and ships." />
+    <!-- OpenGraph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="prd-to-prod" />
+    <meta property="og:url" content="https://ticket-deflection.azurewebsites.net" />
+    <meta property="og:title" content="prd-to-prod — Drop a PRD. Get a deployed app." />
+    <meta property="og:description" content="Autonomous software pipeline: AI decomposes requirements → writes code → reviews PRs → ships to main. Zero human code." />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="prd-to-prod — Drop a PRD. Get a deployed app." />
+    <meta name="twitter:description" content="Autonomous software pipeline: AI decomposes requirements → writes code → reviews PRs → ships to main. Zero human code." />
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com"></script>
     <style>

--- a/TicketDeflection/Pages/Tickets.cshtml
+++ b/TicketDeflection/Pages/Tickets.cshtml
@@ -6,6 +6,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Ticket Feed — prd-to-prod</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com"></script>
     <style>

--- a/TicketDeflection/wwwroot/favicon.svg
+++ b/TicketDeflection/wwwroot/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" fill="#080c12"/>
+  <rect x="0" y="0" width="32" height="2" fill="#00aaff" opacity="0.6"/>
+  <text x="7" y="23" font-family="monospace" font-size="18" font-weight="bold" fill="#00aaff">P</text>
+  <text x="17" y="23" font-family="monospace" font-size="18" font-weight="bold" fill="#3ddc84">▶</text>
+</svg>


### PR DESCRIPTION
Closes #213

## Summary

Adds OpenGraph/Twitter Card meta tags to the landing page and an SVG favicon to all pages, so the app looks polished when shared on LinkedIn/Twitter and in browser tabs.

## Changes

- `TicketDeflection/wwwroot/favicon.svg` — New file: Blueprint×Terminal themed SVG icon (dark `#080c12` background, `--accent` blue top bar, "P▶" monogram in blue/green)
- `TicketDeflection/Pages/Index.cshtml` — Added to `(head)`:
  - `(meta name="description")` for search engines
  - OpenGraph tags: `og:type`, `og:site_name`, `og:url`, `og:title`, `og:description`
  - Twitter Card tags: `twitter:card`, `twitter:title`, `twitter:description`
  - Favicon `(link rel="icon")`
- `TicketDeflection/Pages/Dashboard.cshtml` — Added favicon `(link rel="icon")`
- `TicketDeflection/Pages/Activity.cshtml` — Added favicon `(link rel="icon")`
- `TicketDeflection/Pages/Tickets.cshtml` — Added favicon `(link rel="icon")`

Skipped `og:image`/`twitter:image` per issue constraints — LinkedIn/Twitter will render a text card with title + description, which is sufficient.

## Test Results

```
Passed! - Failed: 0, Passed: 62, Skipped: 0, Total: 62
```

Build succeeds with 0 errors.

---
This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514192430)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22514192430, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514192430 -->

<!-- gh-aw-workflow-id: repo-assist -->