### PR TITLE
[Pipeline] Fix header repo name to link to GitHub repository

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -165,7 +165,7 @@
         <div class="flex items-center gap-4">
             <span class="text-accent font-bold tracking-widest">PRD-TO-PROD</span>
             <span class="text-dim">//</span>
-            <span class="text-dim">samuelkahessay/prd-to-prod</span>
+            <span class="text-dim"><a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="text-dim hover:text-accent transition-colors">samuelkahessay/prd-to-prod</a></span>
         </div>
         <div class="flex items-center gap-2">
             <span class="w-2 h-2 rounded-full bg-[var(--green)] inline-block"></span>


### PR DESCRIPTION
Closes #215

## Changes

Wrapped the `samuelkahessay/prd-to-prod` text in the status bar header with an `(a)` tag linking to https://github.com/samuelkahessay/prd-to-prod. The link opens in a new tab with `rel="noopener noreferrer"`. Styled with `text-dim hover:text-accent transition-colors` to maintain consistency with the Blueprint×Terminal aesthetic without a jarring color change.

The header with this repo name only appears on the Index (landing) page; the other pages (Dashboard, Activity, Tickets) already use `PRD-TO-PROD` as a link back to `/`.

## Test Results

- `dotnet build TicketDeflection.sln` ✅ Build succeeded
- `dotnet test TicketDeflection.sln` ✅ 62/62 tests passed

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514419127)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22514419127, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514419127 -->

<!-- gh-aw-workflow-id: repo-assist -->