### PR TITLE
[Pipeline] Fix hero title: "prd-to-prod" should link to GitHub repository

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -183,7 +183,7 @@
             </h1>
             <p class="text-dim text-base mb-6">Zero human code.<span class="cursor-blink ml-1">█</span></p>
             <p class="text-sm leading-relaxed max-w-2xl" style="color: var(--text)">
-                <span class="text-accent font-bold">prd-to-prod</span> is an autonomous software pipeline powered by
+                <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="text-accent font-bold hover:underline">prd-to-prod</a> is an autonomous software pipeline powered by
                 <span class="text-accent font-bold">gh-aw</span> (GitHub Agentic Workflows).
                 It reads a product requirements document, decomposes it into GitHub Issues,
                 writes code for each one, opens Pull Requests, reviews its own work, merges to main —


### PR DESCRIPTION
Closes #216

## Changes

Replaced the plain `<span class="text-accent font-bold">prd-to-prod</span>` in the hero description paragraph with an `(a)` tag that links to https://github.com/samuelkahessay/prd-to-prod. The link opens in a new tab with `rel="noopener noreferrer"` and preserves the existing `text-accent font-bold` styling plus adds `hover:underline`.

## Test Results

- `dotnet build TicketDeflection.sln` ✅ Build succeeded
- `dotnet test TicketDeflection.sln` ✅ 62/62 tests passed

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514419127)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22514419127, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514419127 -->

<!-- gh-aw-workflow-id: repo-assist -->