### PR TITLE
[Pipeline] Fix OpenGraph og:url to use correct Azure domain

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -10,7 +10,7 @@
     <!-- OpenGraph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="prd-to-prod" />
-    <meta property="og:url" content="https://ticket-deflection.azurewebsites.net" />
+    <meta property="og:url" content="https://prd-to-prod.azurewebsites.net" />
     <meta property="og:title" content="prd-to-prod — Drop a PRD. Get a deployed app." />
     <meta property="og:description" content="Autonomous software pipeline: AI decomposes requirements → writes code → reviews PRs → ships to main. Zero human code." />
     <!-- Twitter Card -->


### PR DESCRIPTION
Closes #220

## Changes

Updated the `og:url` meta tag in `Pages/Index.cshtml` from `(ticketdeflection.azurewebsites.net/redacted)` to `(prdtoprod.azurewebsites.net/redacted)` to match the actual deployed domain.

## Test Results

- `dotnet build TicketDeflection.sln` ✅ Build succeeded
- `dotnet test TicketDeflection.sln` ✅ 62/62 tests passed

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514657714)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22514657714, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514657714 -->

<!-- gh-aw-workflow-id: repo-assist -->