### PR TITLE
[Pipeline] Fix demo button: clear tickets before each simulation run

### DIFF
--- a/TicketDeflection/Endpoints/SimulateEndpoints.cs
+++ b/TicketDeflection/Endpoints/SimulateEndpoints.cs
@@ -53,6 +53,11 @@ public static class SimulateEndpoints
         if (count < 1) count = 1;
         if (count > 100) count = 100;
 
+        // Reset to a clean slate before each demo run
+        db.ActivityLogs.RemoveRange(db.ActivityLogs);
+        db.Tickets.RemoveRange(db.Tickets);
+        await db.SaveChangesAsync();
+
         var autoResolved = 0;
         var escalated = 0;
         var byCategory = new Dictionary<string, int>();


### PR DESCRIPTION
Closes #207

## Changes

Modified `SimulateEndpoints.cs` so that `POST /api/simulate` clears all existing tickets and activity logs before generating new demo data.

**What changed:**
- Added `db.ActivityLogs.RemoveRange(db.ActivityLogs)` and `db.Tickets.RemoveRange(db.Tickets)` at the start of `RunSimulation`
- `await db.SaveChangesAsync()` flushes the deletion before new tickets are created

**Result:** Every press of the "Run Demo" button now starts from a clean slate. The dashboard always reflects exactly the current 25-ticket run rather than accumulated data from previous runs.

**No frontend changes required** — the existing JS already redirects to `/dashboard` after the simulate call succeeds.

## Test Results

- `dotnet build TicketDeflection.sln` ✅ Build succeeded
- `dotnet test TicketDeflection.sln` ✅ 62/62 tests passed

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514657714)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22514657714, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514657714 -->

<!-- gh-aw-workflow-id: repo-assist -->