### PR TITLE
[Pipeline] Fix demo button stuck in executing state after browser back navigation

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -531,6 +531,18 @@
             }
         }
 
+        // Reset demo button on bfcache restore (browser back navigation)
+        window.addEventListener('pageshow', function(event) {
+            if (event.persisted) {
+                const btn = document.getElementById('runDemoBtn');
+                const btnText = document.getElementById('btnText');
+                const btnLoading = document.getElementById('btnLoading');
+                btn.disabled = false;
+                btnText.classList.remove('hidden');
+                btnLoading.classList.add('hidden');
+            }
+        });
+
         // Load live stats from the metrics API
         (async function loadStats() {
             try {


### PR DESCRIPTION
Closes #229

## Changes

Added a `pageshow` event listener to `Pages/Index.cshtml` that resets the Run Demo button to its default ready state when the page is restored from the browser's back-forward cache (`event.persisted === true`).

When a user clicks "Run Demo", the button is disabled and shows a spinner. The page then redirects to `/dashboard`. If the user presses the browser back button, the browser restores the page from bfcache — but the DOM is frozen in the "executing..." state. The `pageshow` event with `persisted: true` is the standard way to detect this and re-enable the button.

### Fix (Pages/Index.cshtml only)

```javascript
window.addEventListener('pageshow', function(event) {
    if (event.persisted) {
        btn.disabled = false;
        btnText.classList.remove('hidden');
        btnLoading.classList.add('hidden');
    }
});
```

## Test Results

- `dotnet build TicketDeflection.sln` ✅ Build succeeded (0 warnings, 0 errors)
- `dotnet test TicketDeflection.sln` ✅ 62/62 tests passed

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514896889)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22514896889, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22514896889 -->

<!-- gh-aw-workflow-id: repo-assist -->