### PR TITLE
[Pipeline] Fix static files not served — register UseStaticFiles middleware

### DIFF
--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -32,6 +32,8 @@ using (var scope = app.Services.CreateScope())
     }
 }
 
+app.UseStaticFiles();
+
 // --- Endpoint Mappings ---
 app.MapPipelineEndpoints();
 app.MapSimulateEndpoints();


### PR DESCRIPTION
Closes #231

## Changes

Added `app.UseStaticFiles()` to `Program.cs` before the endpoint mappings. Without this middleware, ASP.NET Core does not serve files from the `wwwroot/` directory, causing `og-image.png`, `favicon.svg`, and all other static assets to return 404.

## Root Cause

The standard ASP.NET Core static file middleware was never registered in the pipeline. The app was missing the call to `app.UseStaticFiles()` which is required to enable serving `wwwroot/` contents.

## Test Results

- `dotnet build TicketDeflection.sln` ✅ Build succeeded (0 warnings, 0 errors)
- `dotnet test TicketDeflection.sln` ✅ 62/62 tests passed

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22515352565)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22515352565, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22515352565 -->

<!-- gh-aw-workflow-id: repo-assist -->