### PR TITLE
[Pipeline] Fix gh-aw link on landing page to point to GitHub Agentic Workflows

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -186,7 +186,7 @@
             <p class="text-dim text-base mb-6">Zero human code.<span class="cursor-blink ml-1">█</span></p>
             <p class="text-sm leading-relaxed max-w-2xl" style="color: var(--text)">
                 <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="text-accent font-bold hover:underline">prd-to-prod</a> is an autonomous software pipeline powered by
-                <span class="text-accent font-bold">gh-aw</span> (GitHub Agentic Workflows).
+                <a href="https://github.com/github/gh-aw" target="_blank" rel="noopener noreferrer" class="text-accent font-bold hover:underline">gh-aw</a> (GitHub Agentic Workflows).
                 It reads a product requirements document, decomposes it into GitHub Issues,
                 writes code for each one, opens Pull Requests, reviews its own work, merges to main —
                 and self-heals when things break. No human writes a single line of code.


### PR DESCRIPTION
Closes #214

## Changes

Replaced `<span class="text-accent font-bold">gh-aw</span>` with an `(a)` tag that links to https://github.com/github/gh-aw. The link opens in a new tab (`target="_blank"`) with `rel="noopener noreferrer"` for security. Styling is consistent with the existing Blueprint×Terminal aesthetic (`text-accent font-bold hover:underline`).

Note: `prd-to-prod` was already converted to a link in a previous PR (#216), so only the `gh-aw` text needed updating.

## Test Results

- `dotnet build TicketDeflection.sln` ✅ Build succeeded (0 warnings, 0 errors)
- `dotnet test TicketDeflection.sln` ✅ 62/62 tests passed

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22517262248)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22517262248, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22517262248 -->

<!-- gh-aw-workflow-id: repo-assist -->