### PR TITLE
[Pipeline] Dashboard: simplify status bar for single-page specimen

### DIFF
--- a/TicketDeflection/Pages/Dashboard.cshtml
+++ b/TicketDeflection/Pages/Dashboard.cshtml
@@ -160,9 +160,6 @@
     <div class="status-bar px-6 py-2 flex items-center justify-between text-xs">
         <div class="flex items-center gap-4">
             <span class="text-accent font-bold tracking-widest">TICKET DEFLECTION SERVICE</span>
-            <span class="text-accent">/dashboard</span>
-            <a href="/tickets" class="nav-link">/tickets</a>
-            <a href="/activity" class="nav-link">/activity</a>
         </div>
         <div class="flex items-center gap-4">
             <a href="/" class="text-dim hover:text-accent transition-colors">◀ prd-to-prod</a>


### PR DESCRIPTION
Closes #250

## Summary

Removes the `/tickets` and `/activity` navigation links from the dashboard status bar. The status bar now shows only the app brand name and the `◀ prd-to-prod` exit link.

## Changes

- `TicketDeflection/Pages/Dashboard.cshtml`: Removed the `/dashboard` active indicator span and the two `(a)` nav links to `/tickets` and `/activity` from the status bar. No other changes.

## Why

With the dashboard now containing metrics, ticket feed, and interactive submission (#245, #246–#249), the standalone `/tickets` and `/activity` pages are redundant for the demo experience. The status bar nav was creating a false expectation of three separate specimen pages worth visiting.

The `/tickets` and `/activity` pages still exist and function — they are just no longer linked from the dashboard status bar. They will be redirected in #251.

## Test Results

NuGet restore is unavailable in this agent environment (proxy restriction). Build and tests will run in GitHub Actions CI.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22540224586)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22540224586, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22540224586 -->

<!-- gh-aw-workflow-id: repo-assist -->