### PR TITLE
[Pipeline] Redirect /tickets and /activity to /dashboard

### DIFF
--- a/TicketDeflection/Pages/Activity.cshtml.cs
+++ b/TicketDeflection/Pages/Activity.cshtml.cs
@@ -1,7 +1,9 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TicketDeflection.Pages;
 
 public class ActivityModel : PageModel
 {
+    public IActionResult OnGet() => RedirectPermanent("/dashboard");
 }

--- a/TicketDeflection/Pages/Tickets.cshtml.cs
+++ b/TicketDeflection/Pages/Tickets.cshtml.cs
@@ -1,7 +1,9 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TicketDeflection.Pages;
 
 public class TicketsModel : PageModel
 {
+    public IActionResult OnGet() => RedirectPermanent("/dashboard");
 }


### PR DESCRIPTION
Closes #251

## Summary

Replaces the `/tickets` and `/activity` Razor Pages with permanent (HTTP 301) redirects to `/dashboard`. Any visitor arriving via a bookmarked or cached link is seamlessly forwarded to the unified specimen page.

## Changes

- `TicketDeflection/Pages/Tickets.cshtml.cs`: Added `OnGet()` returning `RedirectPermanent("/dashboard")`
- `TicketDeflection/Pages/Activity.cshtml.cs`: Added `OnGet()` returning `RedirectPermanent("/dashboard")`

Both `.cshtml` view files are retained so no Razor compilation errors occur — the redirect fires before the view is rendered.

## Why 301 (permanent) not 302 (temporary)

The issue's intent is that the separate pages are being superseded by the dashboard; a permanent redirect is appropriate so browsers and search engines update their records.

## Test Results

NuGet restore is unavailable in this agent environment (proxy restriction). Build and tests will run in GitHub Actions CI.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22540401317)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22540401317, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22540401317 -->

<!-- gh-aw-workflow-id: repo-assist -->