### PR TITLE
[Pipeline] Fix ClassificationService CS1003 syntax errors breaking CI build

### DIFF
--- a/TicketDeflection/Services/ClassificationService.cs
+++ b/TicketDeflection/Services/ClassificationService.cs
@@ -2,14 +2,14 @@ using TicketDeflection.Models;
 
 namespace TicketDeflection.Services;
 
-public class ClassificationServic
+public class ClassificationService
 {
     private static readonly (string[] Keywords, TicketCategory Category)[] Rules =
     [
-        ("crash", "error", "broken", "bug", "exception"), TicketCategory.Bug),
-        ("how do i", "how to", "help with", "guide"), TicketCategory.HowTo),
-        ("add feature", "request", "wish", "would be nice"), TicketCategory.FeatureRequest),
-        ("login", "password", "account", "billing", "subscription"), TicketCategory.AccountIssue),
+        (["crash", "error", "broken", "bug", "exception"], TicketCategory.Bug),
+        (["how do i", "how to", "help with", "guide"], TicketCategory.HowTo),
+        (["add feature", "request", "wish", "would be nice"], TicketCategory.FeatureRequest),
+        (["login", "password", "account", "billing", "subscription"], TicketCategory.AccountIssue),
     ];
 
     private static readonly Dictionary<TicketCategory, TicketSeverity> SeverityMap = new()


### PR DESCRIPTION
Closes #269

## What

Fixes two syntax errors in `TicketDeflection/Services/ClassificationService.cs` that were breaking the CI build on `main` (run [22546193125](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22546193125)):

1. **Truncated class name**: `ClassificationServic` → `ClassificationService`
2. **CS1003 syntax errors (lines 9–12)**: The string array literals in the tuple initializer were missing the collection-expression brackets. Changed from the broken form:
   ```csharp
   ("crash", "error", "broken", "bug", "exception"), TicketCategory.Bug),
   ```
   to the correct C# 12 collection-expression form:
   ```csharp
   (["crash", "error", "broken", "bug", "exception"], TicketCategory.Bug),
   ```

## Test Results

Local `dotnet build` is blocked by the squid proxy in this environment (NuGet cannot be restored). The fix is a targeted syntax correction — the class name and array-literal syntax are both verifiable by inspection. CI will validate on push.

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22546508259)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22546508259, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22546508259 -->

<!-- gh-aw-workflow-id: repo-assist -->