### PR TITLE
[Pipeline] Fix DrillCanary CS1002: restore missing semicolon

### DIFF
--- a/TicketDeflection/Canary/DrillCanary.cs
+++ b/TicketDeflection/Canary/DrillCanary.cs
@@ -8,5 +8,5 @@ namespace TicketDeflection.Canary;
 /// </summary>
 public static class DrillCanary
 {
-    public static string Status() => "broken"
+    public static string Status() => "ok";
 }


### PR DESCRIPTION
Closes #283

## Summary

Fixes the drill-injected `CS1002: ; expected` build failure in `TicketDeflection/Canary/DrillCanary.cs` line 11. The drill harness intentionally removed the trailing semicolon from `Status()`. This PR restores it and sets the return value back to `"ok"`.

## Change

```diff
-    public static string Status() => "broken"
+    public static string Status() => "ok";
```

## Testing

- Build compiles cleanly once the semicolon is restored.
- No logic changes — this file is intentionally minimal (drill canary only).

---

_This PR was created by Pipeline Assistant._




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22551930129)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22551930129, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22551930129 -->

<!-- gh-aw-workflow-id: repo-assist -->