### PR TITLE
[Pipeline] Dashboard: remove misleading refresh button from metrics bar

### DIFF
--- a/TicketDeflection/Pages/Dashboard.cshtml
+++ b/TicketDeflection/Pages/Dashboard.cshtml
@@ -77,17 +77,6 @@
         .metric-item + .metric-item {
             border-left: 1px solid var(--border);
         }
-        .refresh-btn {
-            background: transparent;
-            border: 1px solid var(--border);
-            color: var(--dim);
-            font-family: var(--mono);
-            font-size: 0.75rem;
-            padding: 6px 16px;
-            cursor: pointer;
-            transition: border-color 0.2s, color 0.2s;
-        }
-        .refresh-btn:hover { border-color: var(--accent); color: var(--accent); }
         .nav-link {
             color: rgba(0, 170, 255, 0.6);
             text-decoration: none;
@@ -260,10 +249,6 @@
             <div class="metric-item flex-1">
                 <div class="metric-lbl">escalated</div>
                 <div id="escalated" class="metric-val metric-val-red mt-1">—</div>
-            </div>
-            <div class="metric-item" style="border-left: 1px solid var(--border);">
-                <div class="metric-lbl">&nbsp;</div>
-                <button onclick="loadMetrics()" class="refresh-btn mt-1">[ refresh ]</button>
             </div>
         </div>
 


### PR DESCRIPTION
Closes #290

## Summary

Removes the `[ refresh ]` button from the metrics bar on the dashboard. The button only updated the three metric counts (total tickets, deflection rate, escalated) but did not refresh the ticket feed below it, creating an inconsistent and misleading user experience.

## Changes

- **`TicketDeflection/Pages/Dashboard.cshtml`**: Removed the fourth `metric-item` cell containing the refresh button and its empty label. The three remaining metric columns now each have `flex-1` and fill the full width of the bar. Also removed the unused `.refresh-btn` CSS rule.

The `loadMetrics()` function itself is preserved — it is still called on page load and after every ticket submission.

## Test Results

```
Build succeeded.
    0 Warning(s)
    0 Error(s)

Passed!  - Failed: 0, Passed: 66, Skipped: 0, Total: 66
```

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22554239387) for issue #290

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22554239387, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22554239387 -->

<!-- gh-aw-workflow-id: repo-assist -->