### PR TITLE
[Pipeline] Dashboard: link footer prd-to-prod text to GitHub repository

### DIFF
--- a/TicketDeflection/Pages/Dashboard.cshtml
+++ b/TicketDeflection/Pages/Dashboard.cshtml
@@ -303,7 +303,7 @@
 
         <div class="text-center text-dim text-xs mt-12 pb-4">
             Built end-to-end by an autonomous AI pipeline ·
-            <a href="/" class="hover:text-accent transition-colors">prd-to-prod</a>
+            <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="hover:text-accent transition-colors">prd-to-prod</a>
         </div>
     </div>
 


### PR DESCRIPTION
Closes #291

## Changes

Updated the `prd-to-prod` link in the dashboard footer (`Dashboard.cshtml`) to point to the GitHub repository instead of the landing page `/`.

**Before:** `(a href="/")prd-to-prod(/a)`  
**After:** `(a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer")prd-to-prod(/a)`

The link now opens in a new tab (`target="_blank"`) with proper security attributes (`rel="noopener noreferrer"`).

## Test Results

- `dotnet build TicketDeflection.sln` — ✅ succeeded (0 warnings, 0 errors)
- `dotnet test TicketDeflection.sln` — ✅ 69/69 tests passed

## Scope

- Single line change in `TicketDeflection/Pages/Dashboard.cshtml` (line 306)
- No workflow files modified
- No other pages or navigation affected

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22554414846)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22554414846, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22554414846 -->

<!-- gh-aw-workflow-id: repo-assist -->