### PR TITLE
[Pipeline] Showcase Discovery & Data Access Layer

### DIFF
--- a/TicketDeflection/Models/ShowcaseModels.cs
+++ b/TicketDeflection/Models/ShowcaseModels.cs
@@ -1,0 +1,132 @@
+using System.Text.Json.Serialization;
+
+namespace TicketDeflection.Models;
+
+public record ShowcaseRun(
+    string Slug,
+    int Number,
+    string Name,
+    string Tag,
+    string TechStack,
+    string Date,
+    string? Deployment,
+    string PrdPath,
+    int IssueCount,
+    int PrCount
+);
+
+public record ShowcaseRunDetail(
+    string Slug,
+    int Number,
+    string Name,
+    string Tag,
+    string TechStack,
+    string Date,
+    string? Deployment,
+    string PrdPath,
+    int IssueCount,
+    int PrCount,
+    ShowcaseStats Stats,
+    IReadOnlyList<ShowcaseTimelineEvent> Timeline
+);
+
+public record ShowcaseStats(
+    int IssuesCreated,
+    int PrsTotal,
+    int PrsMerged,
+    int LinesAdded,
+    int LinesRemoved,
+    int FilesChanged
+);
+
+public record ShowcaseTimelineEvent(
+    DateTimeOffset Timestamp,
+    string Event,
+    int Item,
+    string Title
+);
+
+// Internal JSON deserialization types (snake_case mapping)
+internal sealed class ManifestJson
+{
+    [JsonPropertyName("run")]
+    public ManifestRunJson Run { get; set; } = new();
+
+    [JsonPropertyName("issues")]
+    public int[] Issues { get; set; } = [];
+
+    [JsonPropertyName("pull_requests")]
+    public int[] PullRequests { get; set; } = [];
+}
+
+internal sealed class ManifestRunJson
+{
+    [JsonPropertyName("number")]
+    public int Number { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("tag")]
+    public string Tag { get; set; } = string.Empty;
+
+    [JsonPropertyName("tech_stack")]
+    public string TechStack { get; set; } = string.Empty;
+
+    [JsonPropertyName("date")]
+    public string Date { get; set; } = string.Empty;
+
+    [JsonPropertyName("deployment")]
+    public string? Deployment { get; set; }
+
+    [JsonPropertyName("prd")]
+    public string Prd { get; set; } = string.Empty;
+}
+
+internal sealed class RunDataJson
+{
+    [JsonPropertyName("run")]
+    public ManifestRunJson Run { get; set; } = new();
+
+    [JsonPropertyName("stats")]
+    public RunDataStatsJson Stats { get; set; } = new();
+
+    [JsonPropertyName("timeline")]
+    public TimelineEventJson[] Timeline { get; set; } = [];
+}
+
+internal sealed class RunDataStatsJson
+{
+    [JsonPropertyName("issues_created")]
+    public int IssuesCreated { get; set; }
+
+    [JsonPropertyName("prs_total")]
+    public int PrsTotal { get; set; }
+
+    [JsonPropertyName("prs_merged")]
+    public int PrsMerged { get; set; }
+
+    [JsonPropertyName("lines_added")]
+    public int LinesAdded { get; set; }
+
+    [JsonPropertyName("lines_removed")]
+    public int LinesRemoved { get; set; }
+
+    [JsonPropertyName("files_changed")]
+    public int FilesChanged { get; set; }
+}
+
+internal sealed class TimelineEventJson
+{
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("event")]
+    public string Event { get; set; } = string.Empty;
+
+    [JsonPropertyName("item")]
+    public int Item { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+}

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -10,6 +10,7 @@ builder.Services.AddDbContext<TicketDbContext>(o => o.UseInMemoryDatabase("Ticke
 builder.Services.AddScoped<ClassificationService>();
 builder.Services.AddScoped<MatchingService>();
 builder.Services.AddScoped<PipelineService>();
+builder.Services.AddSingleton<IShowcaseService, ShowcaseService>();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();

--- a/TicketDeflection/Services/IShowcaseService.cs
+++ b/TicketDeflection/Services/IShowcaseService.cs
@@ -1,0 +1,12 @@
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Services;
+
+public interface IShowcaseService
+{
+    /// <summary>Returns all completed showcase runs sorted by Number ascending.</summary>
+    Task<IReadOnlyList<ShowcaseRun>> GetCompletedRunsAsync();
+
+    /// <summary>Returns full run detail for the given slug, or null if not found.</summary>
+    Task<ShowcaseRunDetail?> GetRunDetailAsync(string slug);
+}

--- a/TicketDeflection/Services/ShowcaseService.cs
+++ b/TicketDeflection/Services/ShowcaseService.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Services;
+
+public sealed class ShowcaseService : IShowcaseService
+{
+    private readonly string _showcasePath;
+    private readonly ILogger<ShowcaseService> _logger;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public ShowcaseService(IConfiguration configuration, IWebHostEnvironment env, ILogger<ShowcaseService> logger)
+    {
+        _logger = logger;
+        var configured = configuration["ShowcasePath"];
+        _showcasePath = !string.IsNullOrEmpty(configured)
+            ? configured
+            : Path.Combine(env.ContentRootPath, "..", "showcase");
+    }
+
+    public Task<IReadOnlyList<ShowcaseRun>> GetCompletedRunsAsync()
+    {
+        var results = new List<ShowcaseRun>();
+
+        if (!Directory.Exists(_showcasePath))
+            return Task.FromResult<IReadOnlyList<ShowcaseRun>>(results);
+
+        foreach (var dir in Directory.EnumerateDirectories(_showcasePath))
+        {
+            var slug = Path.GetFileName(dir);
+            var manifestPath = Path.Combine(dir, "manifest.json");
+            var runDataPath = Path.Combine(dir, "run-data.json");
+
+            // Both files must exist — partial runs are excluded
+            if (!File.Exists(manifestPath) || !File.Exists(runDataPath))
+                continue;
+
+            try
+            {
+                var json = File.ReadAllText(manifestPath);
+                var manifest = JsonSerializer.Deserialize<ManifestJson>(json, JsonOpts);
+                if (manifest is null) continue;
+
+                results.Add(new ShowcaseRun(
+                    Slug: slug,
+                    Number: manifest.Run.Number,
+                    Name: manifest.Run.Name,
+                    Tag: manifest.Run.Tag,
+                    TechStack: manifest.Run.TechStack,
+                    Date: manifest.Run.Date,
+                    Deployment: manifest.Run.Deployment,
+                    PrdPath: manifest.Run.Prd,
+                    IssueCount: manifest.Issues.Length,
+                    PrCount: manifest.PullRequests.Length
+                ));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Skipping showcase directory {Slug}: failed to read or parse manifest.json", slug);
+            }
+        }
+
+        results.Sort((a, b) => a.Number.CompareTo(b.Number));
+        return Task.FromResult<IReadOnlyList<ShowcaseRun>>(results);
+    }
+
+    public Task<ShowcaseRunDetail?> GetRunDetailAsync(string slug)
+    {
+        var dir = Path.Combine(_showcasePath, slug);
+        var manifestPath = Path.Combine(dir, "manifest.json");
+        var runDataPath = Path.Combine(dir, "run-data.json");
+
+        if (!File.Exists(manifestPath) || !File.Exists(runDataPath))
+            return Task.FromResult<ShowcaseRunDetail?>(null);
+
+        try
+        {
+            var runDataJson = File.ReadAllText(runDataPath);
+            var runData = JsonSerializer.Deserialize<RunDataJson>(runDataJson, JsonOpts);
+            if (runData is null) return Task.FromResult<ShowcaseRunDetail?>(null);
+
+            var manifestJson = File.ReadAllText(manifestPath);
+            var manifest = JsonSerializer.Deserialize<ManifestJson>(manifestJson, JsonOpts);
+            if (manifest is null) return Task.FromResult<ShowcaseRunDetail?>(null);
+
+            var detail = new ShowcaseRunDetail(
+                Slug: slug,
+                Number: runData.Run.Number,
+                Name: runData.Run.Name,
+                Tag: runData.Run.Tag,
+                TechStack: runData.Run.TechStack,
+                Date: runData.Run.Date,
+                Deployment: runData.Run.Deployment,
+                PrdPath: runData.Run.Prd,
+                IssueCount: manifest.Issues.Length,
+                PrCount: manifest.PullRequests.Length,
+                Stats: new ShowcaseStats(
+                    IssuesCreated: runData.Stats.IssuesCreated,
+                    PrsTotal: runData.Stats.PrsTotal,
+                    PrsMerged: runData.Stats.PrsMerged,
+                    LinesAdded: runData.Stats.LinesAdded,
+                    LinesRemoved: runData.Stats.LinesRemoved,
+                    FilesChanged: runData.Stats.FilesChanged
+                ),
+                Timeline: runData.Timeline.Select(t => new ShowcaseTimelineEvent(
+                    Timestamp: t.Timestamp,
+                    Event: t.Event,
+                    Item: t.Item,
+                    Title: t.Title
+                )).ToList()
+            );
+
+            return Task.FromResult<ShowcaseRunDetail?>(detail);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Skipping showcase run {Slug}: failed to read or parse run-data.json", slug);
+            return Task.FromResult<ShowcaseRunDetail?>(null);
+        }
+    }
+}

--- a/TicketDeflection/TicketDeflection.csproj
+++ b/TicketDeflection/TicketDeflection.csproj
@@ -14,4 +14,9 @@
     <InternalsVisibleTo Include="TicketDeflection.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\showcase\**\*.json" CopyToOutputDirectory="PreserveNewest"
+             Link="showcase\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Closes #298

## Changes

Implements the read-only showcase data access layer that discovers completed pipeline runs from the `showcase/` directory.

### New Files
- **`TicketDeflection/Models/ShowcaseModels.cs`** — `ShowcaseRun`, `ShowcaseRunDetail`, `ShowcaseStats`, `ShowcaseTimelineEvent` records; internal JSON deserialization types with `JsonPropertyName` snake_case mapping
- **`TicketDeflection/Services/IShowcaseService.cs`** — Interface with `GetCompletedRunsAsync()` and `GetRunDetailAsync(slug)`
- **`TicketDeflection/Services/ShowcaseService.cs`** — Singleton implementation that:
  - Enumerates `showcase/` subdirectories
  - Requires **both** `manifest.json` and `run-data.json` to be present (partial runs excluded)
  - Wraps JSON parsing in `try/catch` — logs warning and continues on malformed JSON
  - Reads `ShowcasePath` from `IConfiguration`, defaulting to `../showcase` relative to `ContentRootPath`
  - Returns runs sorted by `Number` ascending

### Modified Files
- **`TicketDeflection/Program.cs`** — Registers `ShowcaseService` as singleton: `builder.Services.AddSingleton(IShowcaseService, ShowcaseService)()`
- **`TicketDeflection/TicketDeflection.csproj`** — Adds `Content` ItemGroup to include `showcase/**/*.json` in publish output

## Test Results

> ⚠️ Local build/test blocked by NuGet proxy restriction (api.nuget.org returns 403 via squid proxy). CI will validate. No new test types were required for this infra issue (tests for the service behaviour are covered in issue #302).

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22560121620)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22560121620, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22560121620 -->

<!-- gh-aw-workflow-id: repo-assist -->