### PR TITLE
[Pipeline] Get Started Section and Footer Links

### DIFF
--- a/TicketDeflection.Tests/LandingPageTests.cs
+++ b/TicketDeflection.Tests/LandingPageTests.cs
@@ -67,4 +67,20 @@ public class LandingPageTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.DoesNotContain("Run Demo", html);
         Assert.DoesNotContain("api/simulate", html);
     }
+
+    [Fact]
+    public async Task LandingPage_ContainsGetStartedSection()
+    {
+        var client = _factory.CreateClient();
+        var html = await client.GetStringAsync("/");
+        Assert.Contains("get started", html);
+    }
+
+    [Fact]
+    public async Task LandingPage_ContainsFooterWithGhAwLink()
+    {
+        var client = _factory.CreateClient();
+        var html = await client.GetStringAsync("/");
+        Assert.Contains("github.com/github/gh-aw", html);
+    }
 }

--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -371,6 +371,33 @@
             </div>
         </section>
 
+        <!-- Get Started -->
+        <section class="mb-14">
+            <div class="text-xs text-dim mb-4 uppercase tracking-widest">// get started — run the pipeline yourself</div>
+            <div class="panel p-6 text-xs">
+                <div class="grid sm:grid-cols-2 gap-6">
+                    <div>
+                        <div class="text-accent font-bold mb-3">four steps to your first autonomous run</div>
+                        <ol class="space-y-3 text-dim leading-relaxed list-none">
+                            <li><span class="text-accent">01 ·</span> fork <a href="https://github.com/samuelkahessay/prd-to-prod" class="text-accent hover:underline">samuelkahessay/prd-to-prod</a> and clone it locally</li>
+                            <li><span class="text-accent">02 ·</span> create <code class="text-white bg-opacity-10 px-1">docs/prd/my-feature.md</code> — describe what you want built, push to <code class="text-white px-1">main</code></li>
+                            <li><span class="text-accent">03 ·</span> open an issue linking your PRD, then comment <code class="text-white px-1">/decompose</code> — the decomposer creates implementation issues automatically</li>
+                            <li><span class="text-accent">04 ·</span> watch <a href="https://github.com/samuelkahessay/prd-to-prod/actions" class="text-accent hover:underline">GitHub Actions</a> — repo-assist implements issues as PRs, pr-review-agent reviews and merges them</li>
+                        </ol>
+                    </div>
+                    <div>
+                        <div class="text-accent font-bold mb-3">useful links</div>
+                        <ul class="space-y-2 text-dim">
+                            <li>→ <a href="https://github.com/samuelkahessay/prd-to-prod" class="text-accent hover:underline">github.com/samuelkahessay/prd-to-prod</a></li>
+                            <li>→ <a href="https://github.com/samuelkahessay/prd-to-prod/blob/main/AGENTS.md" class="text-accent hover:underline">AGENTS.md</a> — coding standards &amp; pipeline conventions</li>
+                            <li>→ <a href="https://github.com/samuelkahessay/prd-to-prod/blob/main/docs/prd/ticket-deflection-prd.md" class="text-accent hover:underline">example PRD</a> — the PRD that built this app</li>
+                            <li>→ <a href="https://github.com/github/gh-aw" class="text-accent hover:underline">gh-aw</a> — the agentic workflow engine powering this pipeline</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <!-- Visual boundary: pipeline story ends, specimen begins -->
         <div class="mb-16" style="border-top: 2px solid var(--border); padding-top: 3rem; position: relative;">
             <div class="text-xs font-bold mb-1 uppercase tracking-widest" style="color: var(--accent)">// specimen — the proof, not the point</div>
@@ -431,7 +458,10 @@
 
         <div class="text-center text-dim text-xs mt-12 pb-4">
             Built end-to-end by an autonomous AI pipeline ·
-            <a href="https://github.com/samuelkahessay/prd-to-prod" class="hover:text-accent transition-colors">prd-to-prod</a>
+            <a href="https://github.com/samuelkahessay/prd-to-prod" class="hover:text-accent transition-colors">prd-to-prod</a> ·
+            <a href="https://github.com/github/gh-aw" class="hover:text-accent transition-colors">gh-aw</a> ·
+            <a href="https://github.com/samuelkahessay/prd-to-prod/blob/main/AGENTS.md" class="hover:text-accent transition-colors">AGENTS.md</a> ·
+            <a href="https://github.com/samuelkahessay/prd-to-prod/blob/main/LICENSE" class="hover:text-accent transition-colors">MIT License</a>
         </div>
 
     </div>


### PR DESCRIPTION
Closes #301

## Changes

Adds a "Get Started" section to the landing page and improves the footer with actionable links.

### `TicketDeflection/Pages/Index.cshtml`
- **New Get Started section** — inserted between the Provenance section and the Specimen boundary, containing:
  - Heading: `// get started — run the pipeline yourself`
  - 4 concrete numbered steps: fork repo → write PRD → `/decompose` command → watch GitHub Actions
  - Links to repo, AGENTS.md, example PRD, and gh-aw
  - Industrial/terminal visual language consistent with the rest of the page
- **Updated footer** — expanded from a single line to include:
  - Link to GitHub repo (prd-to-prod)
  - Link to [gh-aw](https://github.com/github/gh-aw)
  - Link to AGENTS.md
  - Link to MIT License

### `TicketDeflection.Tests/LandingPageTests.cs`
- Added `LandingPage_ContainsGetStartedSection` — verifies "get started" text is present
- Added `LandingPage_ContainsFooterWithGhAwLink` — verifies footer contains `github.com/github/gh-aw`

## Test Results

> ⚠️ Local build/test blocked by NuGet proxy restriction (api.nuget.org returns 403 via squid proxy). CI will validate. The changes are purely HTML/Razor markup and test assertions with no new code paths, so risk of regression is minimal.

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22560121620)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22560121620, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22560121620 -->

<!-- gh-aw-workflow-id: repo-assist -->