### PR TITLE
[Pipeline] Fix showcase path resolution for published deployments

### DIFF
--- a/TicketDeflection.Tests/ShowcaseServicePathTests.cs
+++ b/TicketDeflection.Tests/ShowcaseServicePathTests.cs
@@ -1,0 +1,41 @@
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Tests;
+
+public class ShowcaseServicePathTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public ShowcaseServicePathTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), $"showcase-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose() => Directory.Delete(_tempRoot, recursive: true);
+
+    [Fact]
+    public void ResolveDefaultShowcasePath_PrefersPublishedPath_WhenShowcaseFolderExistsUnderContentRoot()
+    {
+        // Simulate published output: showcase/ sits directly under ContentRootPath
+        var publishedShowcase = Path.Combine(_tempRoot, "showcase");
+        Directory.CreateDirectory(publishedShowcase);
+
+        var resolved = ShowcaseService.ResolveDefaultShowcasePath(_tempRoot);
+
+        Assert.Equal(Path.GetFullPath(publishedShowcase), resolved);
+    }
+
+    [Fact]
+    public void ResolveDefaultShowcasePath_FallsBackToParent_WhenShowcaseFolderAbsent()
+    {
+        // Simulate local dev: ContentRootPath is the project subdir, showcase is at repo root
+        var projectDir = Path.Combine(_tempRoot, "TicketDeflection");
+        Directory.CreateDirectory(projectDir);
+        // Do NOT create projectDir/showcase — should fall back to parent
+
+        var resolved = ShowcaseService.ResolveDefaultShowcasePath(projectDir);
+
+        Assert.Equal(Path.GetFullPath(Path.Combine(_tempRoot, "showcase")), resolved);
+    }
+}

--- a/TicketDeflection/Services/ShowcaseService.cs
+++ b/TicketDeflection/Services/ShowcaseService.cs
@@ -20,7 +20,17 @@ public sealed class ShowcaseService : IShowcaseService
         var configured = configuration["ShowcasePath"];
         _showcasePath = !string.IsNullOrEmpty(configured)
             ? configured
-            : Path.Combine(env.ContentRootPath, "..", "showcase");
+            : ResolveDefaultShowcasePath(env.ContentRootPath);
+    }
+
+    // Resolve the showcase path: prefer ContentRoot/showcase (published output)
+    // and fall back to ContentRoot/../showcase (local development).
+    internal static string ResolveDefaultShowcasePath(string contentRoot)
+    {
+        var publishedPath = Path.GetFullPath(Path.Combine(contentRoot, "showcase"));
+        if (Directory.Exists(publishedPath))
+            return publishedPath;
+        return Path.GetFullPath(Path.Combine(contentRoot, "..", "showcase"));
     }
 
     public Task<IReadOnlyList<ShowcaseRun>> GetCompletedRunsAsync()


### PR DESCRIPTION
Closes #313

## Problem

`/api/showcase/runs` returned `[]` on the deployed Azure site even though all four showcase runs were visible locally. The root cause was that `ShowcaseService` resolved the showcase directory as `ContentRootPath/../showcase`, which correctly points to the repo root in local development but resolves to an incorrect path in the published output directory.

## Root Cause

The `.csproj` copies `showcase/**/*.json` into the published output via `CopyToOutputDirectory`, placing them at `ContentRootPath/showcase/`. However, the service only tried `ContentRootPath/../showcase/` (the parent directory), which doesn't exist in the deployed environment.

| Environment | `ContentRootPath` | Old path | New path |
|---|---|---|---|
| `dotnet run` (dev) | `.../TicketDeflection/` | `.../showcase/` ✓ | `.../showcase/` ✓ |
| `dotnet publish` (deployed) | `/app/` | `/showcase/` ✗ | `/app/showcase/` ✓ |

## Changes

- **`TicketDeflection/Services/ShowcaseService.cs`**: Extracted `ResolveDefaultShowcasePath` (marked `internal` for testability). It first checks `ContentRootPath/showcase` (published mode) and falls back to `ContentRootPath/../showcase` (local dev).
- **`TicketDeflection.Tests/ShowcaseServicePathTests.cs`**: Two new unit tests covering the published-path and dev-fallback cases.

## Test Results

```
Passed! - Failed: 0, Passed: 82, Skipped: 0, Total: 82
```

No configuration overrides required — the fix auto-detects the correct path in both environments.

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22562130129) for issue #313

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22562130129, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22562130129 -->

<!-- gh-aw-workflow-id: repo-assist -->