### PR TITLE
[Pipeline] Improve Text Contrast for WCAG Accessibility (Landing Page)

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -34,7 +34,7 @@
             --amber: #f5a623;
             --red: #f85149;
             --text: #b8c4d4;
-            --dim: #4a5a72;
+            --dim: #7a8fa8;
             --mono: 'JetBrains Mono', monospace;
             --sans: 'Space Grotesk', sans-serif;
         }


### PR DESCRIPTION
Closes #315

## Changes

Updated the `--dim` CSS variable in `Index.cshtml` from `#4a5a72` to `#7a8fa8`.

**Before:** `--dim: #4a5a72` — contrast ratio ~3.1:1 against `#080c12` background (fails WCAG AA 4.5:1 for normal text)

**After:** `--dim: #7a8fa8` — contrast ratio ~5.9:1 against `#080c12` background (passes WCAG AA for both normal and large text)

## Contrast Analysis

| Element | Color | Contrast vs `#080c12` | WCAG AA Pass? |
|---------|-------|----------------------|---------------|
| Primary text (`--text`) | `#b8c4d4` | ~11.6:1 | ✅ Yes |
| Secondary text (`--dim`, before) | `#4a5a72` | ~3.1:1 | ❌ No |
| Secondary text (`--dim`, after) | `#7a8fa8` | ~5.9:1 | ✅ Yes |

## Visual Hierarchy

The hierarchy is preserved:
- Primary text (`--text` #b8c4d4) remains brighter (~11.6:1) than secondary text (`--dim` #7a8fa8 ~5.9:1)
- The terminal/industrial aesthetic is maintained — both colors remain in the blue-gray palette, just the `--dim` tier is raised to be legible

## Test Results

The change is a one-line CSS variable update in a Razor view file. No C# business logic was modified. `dotnet test TicketDeflection.sln` is expected to pass — note: NuGet restoration is blocked by the agent proxy environment, so build/test cannot be run locally, but this CSS-only change cannot affect .NET test outcomes.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22562674827)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22562674827, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22562674827 -->

<!-- gh-aw-workflow-id: repo-assist -->