### PR TITLE
[Pipeline] Extend WCAG Contrast Fix to All User-Facing Pages

### DIFF
--- a/TicketDeflection/Pages/Activity.cshtml
+++ b/TicketDeflection/Pages/Activity.cshtml
@@ -20,7 +20,7 @@
             --amber: #f5a623;
             --red: #f85149;
             --text: #b8c4d4;
-            --dim: #4a5a72;
+            --dim: #7a8fa8;
             --mono: 'JetBrains Mono', monospace;
             --sans: 'Space Grotesk', sans-serif;
         }

--- a/TicketDeflection/Pages/Dashboard.cshtml
+++ b/TicketDeflection/Pages/Dashboard.cshtml
@@ -20,7 +20,7 @@
             --amber: #f5a623;
             --red: #f85149;
             --text: #b8c4d4;
-            --dim: #4a5a72;
+            --dim: #7a8fa8;
             --mono: 'JetBrains Mono', monospace;
             --sans: 'Space Grotesk', sans-serif;
         }

--- a/TicketDeflection/Pages/Tickets.cshtml
+++ b/TicketDeflection/Pages/Tickets.cshtml
@@ -20,7 +20,7 @@
             --amber: #f5a623;
             --red: #f85149;
             --text: #b8c4d4;
-            --dim: #4a5a72;
+            --dim: #7a8fa8;
             --mono: 'JetBrains Mono', monospace;
             --sans: 'Space Grotesk', sans-serif;
         }


### PR DESCRIPTION
Closes #316

## Changes

Updated the `--dim` CSS variable from `#4a5a72` to `#7a8fa8` in three additional user-facing pages:
- `Dashboard.cshtml`
- `Activity.cshtml`
- `Tickets.cshtml`

This matches the fix already applied to `Index.cshtml` in PR #317 (issue #315).

## Contrast Analysis

| Color | Contrast vs `#080c12` | WCAG AA Pass? |
|-------|----------------------|---------------|
| `--dim` before (`#4a5a72`) | ~3.1:1 | ❌ No |
| `--dim` after (`#7a8fa8`) | ~5.9:1 | ✅ Yes |
| `--text` (`#b8c4d4`) | ~11.6:1 | ✅ Yes |

Visual hierarchy is preserved — `--text` remains brighter than `--dim`.

## Test Results

This is a one-line CSS variable change per file with no C# business logic modifications. `dotnet test TicketDeflection.sln` is expected to pass — note: NuGet restoration is blocked by the agent proxy environment, so tests cannot be run locally, but these CSS-only changes cannot affect .NET test outcomes.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22562954751)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22562954751, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22562954751 -->

<!-- gh-aw-workflow-id: repo-assist -->