### PR TITLE
Bootstrap the self-healing MVP path and document the supported setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ See [`showcase/`](showcase/) for detailed run reports.
 
 ## Quick Start
 
+Week-one MVP support is currently validated for the `dotnet-azure` profile.
+See [docs/SELF_HEALING_MVP.md](docs/SELF_HEALING_MVP.md) for the operator runbook.
+
 ```bash
 # 1. Clone
 git clone https://github.com/samuelkahessay/prd-to-prod.git
@@ -54,13 +57,33 @@ bash scripts/bootstrap.sh
 # 4. Configure secrets
 gh aw secrets bootstrap
 
-# 5. Push
+# 5. Verify repo settings
+#    - auto-merge enabled
+#    - delete branch on merge enabled
+#    - active Protect main ruleset
+
+# 6. Push
 git push
 
-# 6. Create an issue with your PRD, then comment: /decompose
+# 7. Create an issue with your PRD, then comment: /decompose
 ```
 
 **Requirements:** GitHub account with Copilot subscription, GitHub CLI (`gh`) v2.0+, `gh-aw` extension.
+
+### Required Secrets
+
+- `COPILOT_GITHUB_TOKEN`
+- `GH_AW_GITHUB_TOKEN`
+- `GH_AW_PROJECT_GITHUB_TOKEN`
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+
+### Required Repo Settings
+
+- Auto-merge enabled
+- Delete branch on merge enabled
+- Active `Protect main` ruleset on `main`
 
 ## How the Pipeline Works
 
@@ -74,6 +97,7 @@ git push
 The loop runs until every issue from the PRD is shipped.
 
 For the full architecture, workflow details, design decisions, and self-healing mechanics, see [**docs/ARCHITECTURE.md**](docs/ARCHITECTURE.md).
+For the MVP setup, verification steps, and drill commands, see [**docs/SELF_HEALING_MVP.md**](docs/SELF_HEALING_MVP.md).
 
 ## License
 

--- a/TicketDeflection/README.md
+++ b/TicketDeflection/README.md
@@ -1,13 +1,15 @@
 # Ticket Deflection Service
 
-An ASP.NET Core 8 web application that automatically classifies, matches, and resolves support tickets against a knowledge base, reducing manual workload.
+An ASP.NET Core 10 web application that automatically classifies, matches, and resolves support tickets against a knowledge base, reducing manual workload.
 
 ## Tech Stack
 
-- **Framework**: ASP.NET Core 8 (Minimal API + Razor Pages)
-- **ORM**: Entity Framework Core 8 (InMemory)
-- **Language**: C# (.NET 8)
+- **Framework**: ASP.NET Core 10 (Minimal API + Razor Pages)
+- **ORM**: Entity Framework Core 9 (InMemory)
+- **Language**: C# (.NET 10)
 - **Testing**: xUnit + Microsoft.AspNetCore.Mvc.Testing
+
+The repository pins the SDK version in [`global.json`](../global.json).
 
 ## Build
 

--- a/docs/SELF_HEALING_MVP.md
+++ b/docs/SELF_HEALING_MVP.md
@@ -1,0 +1,177 @@
+# Self-Healing MVP Runbook
+
+## Supported MVP Scope
+
+Week-one MVP support is currently validated for the `dotnet-azure` profile in
+[.deploy-profile](/Users/skahessay/Documents/Projects/active/prd-to-prod/.deploy-profile).
+
+This repository still contains profile-aware CI and deploy routing for Node and
+Docker, but the reproducible MVP claim in this runbook applies only to the
+current `.NET + Azure App Service` path.
+
+## Required Secrets
+
+Configure these repository secrets before using the autonomous loop:
+
+- `COPILOT_GITHUB_TOKEN`
+- `GH_AW_GITHUB_TOKEN`
+- `GH_AW_PROJECT_GITHUB_TOKEN`
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+
+## Required Repo Settings
+
+Bootstrap configures some of these automatically, but the live repo must end up
+with all of them in place:
+
+- Auto-merge enabled
+- Delete branch on merge enabled
+- Squash merges allowed
+- Active `Protect main` ruleset on `main`
+- `Protect main` requires 1 approving review
+- `Protect main` requires the `review` status check
+- `Protect main` remains squash-only with admin bypass enabled
+
+## Bootstrap Steps
+
+```bash
+gh extension install github/gh-aw
+bash scripts/bootstrap.sh
+gh aw secrets bootstrap
+```
+
+Then verify the repo settings listed above before relying on autonomous merge
+and repair behavior.
+
+## Local Verification
+
+The fastest local MVP check is:
+
+```bash
+bash scripts/verify-mvp.sh --skip-audit
+```
+
+That command runs the shell decision-logic tests plus:
+
+```bash
+dotnet test TicketDeflection.sln
+```
+
+## Audit Drill Command
+
+Use the known-good March 1, 2026 drill commit to verify the end-to-end repair
+path without mutating `main`:
+
+```bash
+bash scripts/verify-mvp.sh --audit-commit ff2f18746416dfb8ae8bfe1e414e031983a5fb73
+```
+
+The raw audit command is:
+
+```bash
+bash scripts/self-healing-drill.sh audit ff2f18746416dfb8ae8bfe1e414e031983a5fb73
+```
+
+## Live Drill Command
+
+Run a real canary failure only from a clean local `main` with push access:
+
+```bash
+bash scripts/self-healing-drill.sh run main_build_syntax
+```
+
+This intentionally pushes a broken commit to `main` and relies on the pipeline
+to heal it.
+
+## Observable Evidence
+
+For a passing audit or live drill, confirm all of the following evidence exists:
+
+- A failing CI or deploy run URL
+- A linked `[Pipeline] CI Build Failure` issue or `[CI Incident]` escalation
+- An auto-dispatch or requeue run URL
+- A repair PR URL
+- A green CI run URL on the repair PR
+- A merged commit on `main`
+- A successful main recovery run URL
+- A final drill JSON report under `drills/reports/`
+
+## Known Limitations
+
+- There is no rollback automation.
+- There is no external paging, Slack, or incident-management integration.
+- Week-one MVP support is not claimed for profiles other than `dotnet-azure`.
+- Watchdog and requeue behavior are mostly redispatch logic, not root-cause
+  diagnosis.
+
+## Troubleshooting
+
+### Missing `GH_AW_GITHUB_TOKEN`
+
+Symptoms:
+
+- CI failure routing logs warnings about `GH_AW_GITHUB_TOKEN` being unavailable.
+- Repair commands are not posted.
+- Auto-created failure issues warn that the self-healing loop is disabled.
+
+Check:
+
+```bash
+gh secret list
+```
+
+### Missing self-healing labels
+
+Symptoms:
+
+- PR incident labels such as `ci-failure`, `repair-in-progress`, or
+  `repair-escalated` are missing.
+- Watchdog or router logs warning messages when adding labels.
+
+Fix:
+
+```bash
+bash scripts/bootstrap.sh
+gh label list
+```
+
+### Stale branch or push failure
+
+Symptoms:
+
+- Repo-assist comments that it could not push fixes to an existing PR branch.
+- The PR remains open with `CHANGES_REQUESTED` or repeated CI failures.
+- `[aw]` issues or escalation issues appear after repeated retries.
+
+What it means:
+
+- The self-healing loop can redispatch and escalate, but it does not yet
+  implement an automatic rebase or PR recreation strategy.
+
+### Deferred dispatch vs direct dispatch
+
+Symptoms:
+
+- Drill reports show `dispatch_substate=deferred` or `deferred->requeued`.
+- The issue contains a hidden `self-healing-dispatch-deferred:v1` marker.
+
+Interpretation:
+
+- `direct`: auto-dispatch ran immediately.
+- `deferred`: repo-assist was already active, so dispatch was postponed.
+- `deferred->requeued`: the requeue workflow picked it up later.
+
+### Local tests pass but GitHub audit fails
+
+Symptoms:
+
+- `dotnet test TicketDeflection.sln` passes locally.
+- `bash scripts/self-healing-drill.sh audit <sha>` fails.
+
+Typical causes:
+
+- Required secrets or labels are missing in the GitHub repo.
+- Repo settings differ from the documented `Protect main` ruleset.
+- The audited commit predates the current self-healing workflow behavior.
+- The repair path completed manually instead of via autonomous dispatch.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,7 +21,11 @@ for label in "pipeline:0075ca:Pipeline-managed issue" \
              "ready:0e8a16:Ready for implementation" \
              "completed:0e8a16:Completed and merged" \
              "report:c5def5:Status report" \
-             "bug-intake:e4e669:Filed via bug-report template"; do
+             "bug-intake:e4e669:Filed via bug-report template" \
+             "agentic-workflows:ededed:Agentic workflow failure notification" \
+             "ci-failure:C24E3F:Tracks active CI repair incidents on pull requests" \
+             "repair-in-progress:D97706:Automated CI repair has been dispatched or is actively retrying" \
+             "repair-escalated:B60205:Automated CI repair exhausted retries and needs human attention"; do
   IFS=: read -r name color desc <<< "$label"
   gh label create "$name" --color "$color" --description "$desc" --force 2>/dev/null || true
 done
@@ -52,10 +56,12 @@ fi
 # Configure repo settings for pipeline
 echo "Configuring repo settings..."
 gh api repos/{owner}/{repo} --method PATCH \
+  -f allow_auto_merge=true \
   -f squash_merge_commit_message="PR_BODY" \
   -f squash_merge_commit_title="PR_TITLE" \
   --silent 2>/dev/null || true
 echo "Squash merge set to use PR body (preserves Closes #N)."
+echo "Auto-merge enabled."
 
 # Configure secrets reminder
 echo ""
@@ -64,7 +70,13 @@ echo ""
 echo "Next steps:"
 echo "1. Ensure GitHub Copilot is configured as the AI engine"
 echo "   Run: gh aw secrets bootstrap"
-echo "2. Push changes: git push"
-echo "3. Test the pipeline:"
+echo "2. Verify required repo settings:"
+echo "   - 'Protect main' ruleset exists and is active"
+echo "   - Ruleset requires 1 approving review"
+echo "   - Ruleset requires the 'review' status check"
+echo "   - Ruleset allows squash-only merges"
+echo "   - Admin bypass remains enabled"
+echo "3. Push changes: git push"
+echo "4. Test the pipeline:"
 echo "   - Create an issue with a PRD, then comment /decompose"
 echo "   - Or run: gh aw run prd-decomposer"

--- a/scripts/tests/test-verify-mvp.sh
+++ b/scripts/tests/test-verify-mvp.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/verify-mvp.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+LOG_FILE="$TMPDIR/calls.log"
+
+cat > "$TMPDIR/bin/bash" <<EOF
+#!/bin/bash
+printf 'bash %s\n' "\$*" >> "$LOG_FILE"
+exit 0
+EOF
+
+cat > "$TMPDIR/bin/dotnet" <<EOF
+#!/bin/bash
+printf 'dotnet %s\n' "\$*" >> "$LOG_FILE"
+exit 0
+EOF
+
+chmod +x "$TMPDIR/bin/bash" "$TMPDIR/bin/dotnet"
+
+run_and_capture() {
+  : > "$LOG_FILE"
+  PATH="$TMPDIR/bin:$PATH" /bin/bash "$SCRIPT" "$@" >/dev/null
+  cat "$LOG_FILE"
+}
+
+DEFAULT_CALLS=$(run_and_capture)
+printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/self-healing-drill.sh audit ff2f18746416dfb8ae8bfe1e414e031983a5fb73" >/dev/null
+
+SKIP_CALLS=$(run_and_capture --skip-audit)
+if printf '%s\n' "$SKIP_CALLS" | grep -F "bash scripts/self-healing-drill.sh audit" >/dev/null; then
+  echo "FAIL: --skip-audit should suppress the drill audit" >&2
+  exit 1
+fi
+
+OVERRIDE_CALLS=$(run_and_capture --audit-commit abc123)
+printf '%s\n' "$OVERRIDE_CALLS" | grep -F "bash scripts/self-healing-drill.sh audit abc123" >/dev/null
+
+echo "verify-mvp.sh tests passed"

--- a/scripts/verify-mvp.sh
+++ b/scripts/verify-mvp.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+KNOWN_GOOD_AUDIT_COMMIT="ff2f18746416dfb8ae8bfe1e414e031983a5fb73"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: verify-mvp.sh [--skip-audit] [--audit-commit <sha>]
+USAGE
+  exit 2
+}
+
+SKIP_AUDIT=false
+AUDIT_COMMIT="$KNOWN_GOOD_AUDIT_COMMIT"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --skip-audit)
+      SKIP_AUDIT=true
+      shift
+      ;;
+    --audit-commit)
+      [ "$#" -lt 2 ] && usage
+      AUDIT_COMMIT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+CHECKS=(
+  "bash scripts/tests/test-ci-failure-context.sh"
+  "bash scripts/tests/test-classify-pipeline-issue.sh"
+  "bash scripts/tests/test-render-ci-repair-command.sh"
+  "bash scripts/tests/test-run-lifecycle-lib.sh"
+  "bash scripts/tests/test-self-healing-drill-dispatch-substate.sh"
+  "bash scripts/tests/test-self-healing-drill-workflow-matching.sh"
+  "dotnet test TicketDeflection.sln"
+)
+
+run_check() {
+  local check_cmd="$1"
+
+  echo "==> ${check_cmd}"
+  if ! (cd "$REPO_ROOT" && eval "$check_cmd"); then
+    FAILED_CHECKS+=("$check_cmd")
+  fi
+}
+
+FAILED_CHECKS=()
+
+for check_cmd in "${CHECKS[@]}"; do
+  run_check "$check_cmd"
+done
+
+if [ "$SKIP_AUDIT" != "true" ]; then
+  run_check "bash scripts/self-healing-drill.sh audit ${AUDIT_COMMIT}"
+fi
+
+if [ "${#FAILED_CHECKS[@]}" -gt 0 ]; then
+  echo "FAIL (${#FAILED_CHECKS[@]} failed checks)"
+  for failed in "${FAILED_CHECKS[@]}"; do
+    echo " - ${failed}"
+  done
+  exit 1
+fi
+
+if [ "$SKIP_AUDIT" = "true" ]; then
+  echo "PASS (local verification)"
+else
+  echo "PASS (local verification + audit ${AUDIT_COMMIT})"
+fi


### PR DESCRIPTION
Closes #322

## Summary
- align bootstrap with the live self-healing repo configuration
- document the supported `dotnet-azure` MVP setup, verification path, and known limits
- add `scripts/verify-mvp.sh` plus a focused shell test for the verification contract

## Testing
- `bash scripts/tests/test-verify-mvp.sh`
- `bash scripts/verify-mvp.sh --skip-audit`
- `bash scripts/verify-mvp.sh --audit-commit ff2f18746416dfb8ae8bfe1e414e031983a5fb73`