### PR TITLE
Align external bug intake with secure label-based dispatch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,14 +8,6 @@ body:
         Thanks for reporting a bug. Please fill out the sections below so the pipeline can reproduce and fix the issue.
 
   - type: textarea
-    id: intake-marker
-    attributes:
-      label: intake-marker
-      value: "<!-- bug-intake-template -->"
-    validations:
-      required: true
-
-  - type: textarea
     id: what-happened
     attributes:
       label: What happened?

--- a/.github/workflows/auto-dispatch.yml
+++ b/.github/workflows/auto-dispatch.yml
@@ -15,6 +15,9 @@ concurrency:
 
 jobs:
   dispatch:
+    # Security model: external reporters cannot self-assign labels on free-form
+    # issues, but GitHub issue forms apply labels server-side. The `pipeline`
+    # label is therefore the trusted dispatch gate for template-filed bugs.
     if: |
       !startsWith(github.event.issue.title, '[CI Incident]') &&
       github.event.issue.title != '[Pipeline] Status' &&

--- a/docs/plans/2026-03-01-external-bug-intake-plan.md
+++ b/docs/plans/2026-03-01-external-bug-intake-plan.md
@@ -1,195 +1,115 @@
 # External Bug Intake Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+**Goal:** Allow external (non-collaborator) users to file bug reports that the
+pipeline picks up and fixes autonomously, without trusting any user-controlled
+issue body content.
 
-**Goal:** Allow external (non-collaborator) users to file bug reports that the pipeline picks up and fixes autonomously.
-
-**Architecture:** A GitHub YAML issue form template auto-assigns `bug` + `pipeline` labels and embeds a hidden marker in the issue body. The existing `auto-dispatch.yml` author gate is relaxed to accept issues containing that marker, so template-filed bugs from anyone enter the pipeline while free-form issues from non-collaborators are still blocked.
+**Architecture:** A GitHub YAML issue form template auto-assigns `bug` and
+`pipeline` labels server-side. `auto-dispatch.yml` continues to dispatch only
+actionable `pipeline` issues. Because non-collaborators cannot self-assign
+labels on free-form issues, template-filed bugs enter the pipeline while blank
+issues remain blocked unless a maintainer intentionally labels them.
 
 **Tech Stack:** GitHub Actions, GitHub Issue Form Templates (YAML)
 
 ---
 
-### Task 1: Create Bug Report Issue Template
+### Task 1: Simplify the Bug Report Issue Template
 
 **Files:**
-- Create: `.github/ISSUE_TEMPLATE/bug-report.yml`
+- Modify: `.github/ISSUE_TEMPLATE/bug-report.yml`
 
-**Context:** GitHub supports YAML-based issue form templates that render as structured forms. The `labels` field auto-assigns labels at creation time (on the `issues:opened` event). A hidden `textarea` field with a default value embeds the intake marker in the body without the reporter seeing it.
+**Context:** The secure gate is the server-applied `pipeline` label, not any
+issue body marker. The template should only collect reproduction details and
+assign labels.
 
-**Step 1: Create the template file**
+**Step 1: Remove the unused intake marker field**
+
+The template should keep:
 
 ```yaml
 name: Bug Report
 description: Report a bug in the deployed application
 labels: ["bug", "pipeline"]
-body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for reporting a bug. Please fill out the sections below so the pipeline can reproduce and fix the issue.
-
-  - type: textarea
-    id: intake-marker
-    attributes:
-      label: intake-marker
-      value: "<!-- bug-intake-template -->"
-    validations:
-      required: true
-
-  - type: textarea
-    id: what-happened
-    attributes:
-      label: What happened?
-      description: Describe the bug. What did you see?
-      placeholder: "When I clicked X, Y happened instead of Z."
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected-behavior
-    attributes:
-      label: What should have happened?
-      description: Describe the correct behavior you expected.
-      placeholder: "Clicking X should have done Z."
-    validations:
-      required: true
-
-  - type: textarea
-    id: steps-to-reproduce
-    attributes:
-      label: Steps to reproduce
-      description: Exact steps to trigger the bug. The agent needs these to reproduce it.
-      placeholder: |
-        1. Go to '...'
-        2. Click on '...'
-        3. Scroll down to '...'
-        4. See error
-    validations:
-      required: true
-
-  - type: textarea
-    id: environment
-    attributes:
-      label: Environment (optional)
-      description: Browser, OS, or any other relevant context.
-      placeholder: "Chrome 120, macOS 14.2"
-    validations:
-      required: false
 ```
+
+and only collect:
+
+- what happened
+- expected behavior
+- steps to reproduce
+- environment
+
+It should not include a hidden or visible marker field in the body.
 
 **Step 2: Verify file is valid YAML**
 
-Run: `python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/bug-report.yml'))" && echo "Valid YAML"`
+Run: `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/bug-report.yml"); puts "Valid YAML"'`
 Expected: `Valid YAML`
 
 **Step 3: Commit**
 
 ```bash
 git add .github/ISSUE_TEMPLATE/bug-report.yml
-git commit -m "feat: add bug report issue template with intake marker
-
-Structured form auto-assigns bug+pipeline labels and embeds
-a hidden marker for auto-dispatch to recognize template-filed issues."
+git commit -m "fix: remove dead intake marker from bug report template"
 ```
 
 ---
 
-### Task 2: Relax Author Gate in Auto-Dispatch
+### Task 2: Keep Auto-Dispatch on the Label-Based Gate
 
 **Files:**
-- Modify: `.github/workflows/auto-dispatch.yml:22-25`
+- Modify: `.github/workflows/auto-dispatch.yml`
 
-**Context:** The current author gate (line 22-24) restricts dispatch to OWNER, MEMBER, COLLABORATOR, or `github-actions[bot]`. We add a third condition: the issue body contains the bug-intake-template marker. This allows template-filed bugs from anyone to enter the pipeline.
+**Context:** The current secure model is already label-based. Do not add a body
+marker or any other user-editable bypass signal. Instead, make the intent clear
+in the workflow.
 
-**Step 1: Edit the author gate condition**
+**Step 1: Add an inline comment describing the security model**
 
-In `.github/workflows/auto-dispatch.yml`, the current condition block at lines 22-25:
+The workflow condition should continue to gate on actionable `pipeline` issues.
+Add a short comment near the `if:` condition explaining:
 
-```yaml
-      (
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
-        github.event.issue.user.login == 'github-actions[bot]'
-      ) &&
-```
+- issue forms apply labels server-side
+- non-collaborators cannot self-assign labels on free-form issues
+- the `pipeline` label is the trusted dispatch signal
 
-Replace with:
+**Step 2: Verify the workflow is valid YAML**
 
-```yaml
-      (
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
-        github.event.issue.user.login == 'github-actions[bot]' ||
-        contains(github.event.issue.body, '<!-- bug-intake-template -->')
-      ) &&
-```
-
-**Step 2: Verify the full `if` condition is still valid YAML**
-
-Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/auto-dispatch.yml'))" && echo "Valid YAML"`
+Run: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/auto-dispatch.yml"); puts "Valid YAML"'`
 Expected: `Valid YAML`
 
 **Step 3: Commit**
 
 ```bash
 git add .github/workflows/auto-dispatch.yml
-git commit -m "feat: allow template-filed bug reports to bypass author gate
-
-External reporters using the bug report template embed a hidden
-marker that auto-dispatch recognizes, letting their issues enter
-the pipeline without collaborator status."
+git commit -m "docs(auto-dispatch): clarify label-based external intake gate"
 ```
 
 ---
 
-### Task 3: Push Branch and Create PR
+### Task 3: Validate the External Intake Path
 
-**Step 1: Push the branch**
+**Checks:**
 
-```bash
-git push -u origin feat/external-bug-intake
-```
-
-**Step 2: Create the PR**
-
-```bash
-gh pr create \
-  --title "External bug intake — template + auto-dispatch gate" \
-  --body "$(cat <<'EOF'
-## Summary
-- Adds a structured bug report issue template that auto-assigns `bug` + `pipeline` labels
-- Relaxes the auto-dispatch author gate to recognize template-filed issues from non-collaborators
-- Enables the L3 demo: external user files a bug → pipeline picks it up → autonomous fix
-
-## How it works
-1. Reporter opens a bug via the new template form
-2. Template auto-assigns `bug` + `pipeline` labels and embeds a hidden `<!-- bug-intake-template -->` marker
-3. `auto-dispatch.yml` sees the marker and bypasses the collaborator-only author gate
-4. `repo-assist` picks up the issue and processes it like any other pipeline bug
-
-## What doesn't change
-- Collaborator-filed issues work exactly as before
-- CI self-healing loop unchanged
-- Free-form issues from non-collaborators still blocked (no marker = no dispatch)
-
-## Test plan
-- [ ] Template renders correctly on GitHub issue creation page
-- [ ] Filing a bug via template auto-assigns `bug` and `pipeline` labels
-- [ ] Auto-dispatch fires for a template-filed issue from a non-collaborator
-- [ ] Free-form issue from non-collaborator does NOT trigger auto-dispatch
-- [ ] Existing self-healing drill still passes
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
+1. Open the GitHub issue creation page and confirm the bug report form is
+   available.
+2. Confirm a template-filed bug receives `bug` and `pipeline` labels.
+3. Confirm `auto-dispatch.yml` runs for that labeled issue.
+4. Confirm a blank free-form issue from a non-collaborator does not enter the
+   pipeline unless a maintainer adds the labels intentionally.
 
 ---
 
 ## Acceptance Criteria
 
-1. A structured bug report issue template exists and is selectable when creating a new issue
-2. When an issue is created via the bug report template, it automatically receives `pipeline` and `bug` labels
-3. An issue created via the bug report template by a non-collaborator triggers auto-dispatch
-4. An issue created WITHOUT the template by a non-collaborator does NOT trigger auto-dispatch
-5. The existing self-healing flow (CI failure → issue → repair) continues to work unchanged
-6. Build passes, deploy succeeds
+1. A structured bug report issue template exists and is selectable when
+   creating a new issue.
+2. When an issue is created via the bug report template, it automatically
+   receives `pipeline` and `bug` labels.
+3. An issue created via the bug report template by a non-collaborator triggers
+   auto-dispatch through the label gate.
+4. Free-form issues from non-collaborators do not gain pipeline access via any
+   user-editable body marker.
+5. `auto-dispatch.yml` does not rely on issue body content as an authorization
+   signal.


### PR DESCRIPTION
Closes #324

## Summary
- remove the dead intake marker from the bug report issue template
- document the label-based security model in `auto-dispatch.yml`
- rewrite the external bug intake plan so it does not propose a spoofable body-marker bypass

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/bug-report.yml"); YAML.load_file(".github/workflows/auto-dispatch.yml"); puts "Valid YAML"'`\n- `git diff --check`