### PR TITLE
Add a healing pause switch and workflow safety guards

### DIFF
--- a/.github/workflows/auto-dispatch-requeue.yml
+++ b/.github/workflows/auto-dispatch-requeue.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  contents: read
   actions: write
   issues: write
 
@@ -17,11 +18,28 @@ concurrency:
 jobs:
   requeue:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PIPELINE_HEALING_ENABLED: ${{ vars.PIPELINE_HEALING_ENABLED }}
     steps:
       - name: Checkout repository helpers
         uses: actions/checkout@v4
 
+      - name: Check healing pause switch
+        id: healing
+        run: |
+          if scripts/healing-control.sh is-enabled; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=healing_paused" >> "$GITHUB_OUTPUT"
+            echo "Autonomous healing is paused via PIPELINE_HEALING_ENABLED."
+          fi
+
       - name: Re-dispatch deferred actionable issue
+        if: steps.healing.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}

--- a/.github/workflows/auto-dispatch.yml
+++ b/.github/workflows/auto-dispatch.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, labeled]
 
 permissions:
+  contents: read
   actions: write
   issues: write
 
@@ -28,11 +29,35 @@ jobs:
         contains(github.event.issue.labels.*.name, 'test')
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PIPELINE_HEALING_ENABLED: ${{ vars.PIPELINE_HEALING_ENABLED }}
     steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/healing-control.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Check healing pause switch
+        id: healing
+        run: |
+          if scripts/healing-control.sh is-enabled; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=healing_paused" >> "$GITHUB_OUTPUT"
+            echo "Autonomous healing is paused via PIPELINE_HEALING_ENABLED."
+          fi
+
       - name: Debounce (let issue burst settle)
+        if: steps.healing.outputs.skip != 'true'
         run: sleep 15
 
       - name: Skip when repo-assist already active
+        if: steps.healing.outputs.skip != 'true'
         id: guard
         env:
           GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
@@ -56,7 +81,7 @@ jobs:
           fi
 
       - name: Record deferred dispatch marker
-        if: steps.guard.outputs.skip == 'true'
+        if: steps.healing.outputs.skip != 'true' && steps.guard.outputs.skip == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -81,7 +106,7 @@ jobs:
             echo "::warning::Could not record deferred dispatch marker on issue #${ISSUE_NUMBER}"
 
       - name: Dispatch repo-assist scheduled mode
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.healing.outputs.skip != 'true' && steps.guard.outputs.skip != 'true'
         id: dispatch_repo_assist
         env:
           GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
@@ -113,7 +138,7 @@ jobs:
           echo "repo_assist_run_url=${REPO_ASSIST_RUN_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Record dispatch marker
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.healing.outputs.skip != 'true' && steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -33,12 +33,34 @@ jobs:
   route-failure:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'failure'
+    timeout-minutes: 15
+    env:
+      PIPELINE_HEALING_ENABLED: ${{ vars.PIPELINE_HEALING_ENABLED }}
     steps:
       - name: Checkout repository helpers
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 50
+
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/healing-control.sh
+          sparse-checkout-cone-mode: false
+          path: .workflow-helpers
+
+      - name: Check healing pause switch
+        id: healing
+        run: |
+          if .workflow-helpers/scripts/healing-control.sh is-enabled; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "paused=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "paused=true" >> "$GITHUB_OUTPUT"
+            echo "Autonomous healing is paused via PIPELINE_HEALING_ENABLED."
+          fi
 
       - name: Route failing CI run
         env:
@@ -49,6 +71,7 @@ jobs:
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEALING_PAUSED: ${{ steps.healing.outputs.paused }}
           PULL_REQUESTS_JSON: ${{ toJson(github.event.workflow_run.pull_requests) }}
         run: |
           set -euo pipefail
@@ -253,6 +276,17 @@ jobs:
 
           PR_NUMBER=$(printf '%s' "$PULL_REQUESTS_JSON" | jq -r '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
+            if [ "${HEALING_PAUSED:-false}" = "true" ]; then
+              TITLE="[CI Incident] ${HEAD_BRANCH} failure: ${SHORT_SUMMARY}"
+              BODY=$(render_incident_body \
+                "Autonomous healing is paused via PIPELINE_HEALING_ENABLED, so no auto-dispatchable pipeline repair issue was created." \
+                "- **Branch**: \`${HEAD_BRANCH}\`")
+              DRILL_ID=$(extract_drill_id)
+              BODY=$(append_drill_metadata "$BODY" "$DRILL_ID")
+              create_or_update_incident_issue "$TITLE" "$BODY"
+              exit 0
+            fi
+
             TITLE="[Pipeline] CI Build Failure on main: ${SHORT_SUMMARY}"
             BODY=$(printf '%s\n' \
               "## CI Build Failure on \`main\`" \
@@ -364,6 +398,20 @@ jobs:
           DETECTED_STATE=$(render_state_body detected "$LINKED_ISSUE" 1 "$FAILURE_TYPE" "$FAILURE_SIGNATURE" "$FAILURE_SUMMARY" "$FAILURE_EXCERPT")
           upsert_comment "$GH_TOKEN" "$PR_NUMBER" "$STATE_COMMENT_ID" "$DETECTED_STATE"
           add_pr_label "ci-failure"
+
+          if [ "${HEALING_PAUSED:-false}" = "true" ]; then
+            ESCALATED_STATE=$(render_state_body escalated "$LINKED_ISSUE" 1 "$FAILURE_TYPE" "$FAILURE_SIGNATURE" "$FAILURE_SUMMARY" "$FAILURE_EXCERPT")
+            upsert_comment "$GH_TOKEN" "$PR_NUMBER" "$STATE_COMMENT_ID" "$ESCALATED_STATE"
+            remove_pr_label "repair-in-progress"
+            add_pr_label "repair-escalated"
+            TITLE="[CI Incident] Escalation: PR #${PR_NUMBER} healing paused"
+            BODY=$(render_incident_body \
+              "Autonomous healing is paused via PIPELINE_HEALING_ENABLED, so the router recorded the incident but did not post a repair command." \
+              "- **PR**: #${PR_NUMBER} (${PR_URL})\n- **Branch**: \`${HEAD_BRANCH}\`\n- **Linked Issue**: #${LINKED_ISSUE}")
+            create_or_update_incident_issue "$TITLE" "$BODY"
+            exit 0
+          fi
+
           add_pr_label "repair-in-progress"
           remove_pr_label "repair-escalated"
 

--- a/.github/workflows/ci-failure-resolve.yml
+++ b/.github/workflows/ci-failure-resolve.yml
@@ -24,6 +24,7 @@ jobs:
   resolve-failure:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 10
     steps:
       - name: Checkout repository helpers
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   check-profile:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
     steps:
@@ -31,6 +32,7 @@ jobs:
     needs: check-profile
     if: needs.check-profile.outputs.should-run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4

--- a/.github/workflows/pipeline-watchdog.yml
+++ b/.github/workflows/pipeline-watchdog.yml
@@ -28,11 +28,28 @@ concurrency:
 jobs:
   watchdog:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PIPELINE_HEALING_ENABLED: ${{ vars.PIPELINE_HEALING_ENABLED }}
     steps:
       - name: Checkout repository helpers
         uses: actions/checkout@v4
 
+      - name: Check healing pause switch
+        id: healing
+        run: |
+          if scripts/healing-control.sh is-enabled; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=healing_paused" >> "$GITHUB_OUTPUT"
+            echo "Autonomous healing is paused via PIPELINE_HEALING_ENABLED."
+          fi
+
       - name: Check for stalled pipeline items
+        if: steps.healing.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}

--- a/.github/workflows/pr-review-submit.yml
+++ b/.github/workflows/pr-review-submit.yml
@@ -59,6 +59,7 @@ permissions:
 jobs:
   submit-review-comment:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
@@ -70,7 +71,26 @@ jobs:
       group: "pr-review-submit-${{ github.event.issue.number }}"
       cancel-in-progress: false
 
+    env:
+      PIPELINE_HEALING_ENABLED: ${{ vars.PIPELINE_HEALING_ENABLED }}
+
     steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/healing-control.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Check healing pause switch
+        id: healing
+        run: |
+          if scripts/healing-control.sh is-enabled; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Autonomous healing is paused via PIPELINE_HEALING_ENABLED."
+          fi
+
       - name: Check idempotency (skip if same verdict already reviewed at current HEAD)
         id: idempotency
         env:
@@ -183,22 +203,28 @@ jobs:
             -f description="Review completed: ${VERDICT}"
           echo "Set 'review' status check to success on ${HEAD_SHA} (verdict: ${VERDICT})"
 
-      - name: Mark draft PR ready and enable auto-merge (APPROVE only)
+      - name: Mark draft PR ready (APPROVE only)
         if: steps.idempotency.outputs.skip != 'true' && steps.review.outputs.verdict == 'APPROVE'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_DRAFT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft -q '.isDraft')
+          if [ "$PR_DRAFT" = "true" ]; then
+            gh pr ready "$PR_NUMBER" --repo "$REPO" || echo "::warning::Could not mark PR as ready"
+          else
+            echo "PR #${PR_NUMBER} is already ready for review."
+          fi
+
+      - name: Enable auto-merge (APPROVE only)
+        if: steps.idempotency.outputs.skip != 'true' && steps.review.outputs.verdict == 'APPROVE' && steps.healing.outputs.enabled == 'true'
+        env:
           MERGE_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
           PR_TITLE: ${{ steps.review.outputs.pr_title }}
           REPO: ${{ github.repository }}
         run: |
-          # If the PR is still a draft, mark it ready for review
-          PR_DRAFT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft -q '.isDraft')
-          if [ "$PR_DRAFT" = "true" ]; then
-            gh pr ready "$PR_NUMBER" --repo "$REPO" || echo "::warning::Could not mark PR as ready"
-          fi
-
-          # Enable auto-merge only for [Pipeline] PRs (human PRs should be merged manually)
           if [[ "$PR_TITLE" == "[Pipeline]"* ]]; then
             if [ -z "$MERGE_TOKEN" ]; then
               echo "::error::GH_AW_GITHUB_TOKEN is required for pipeline auto-merge so downstream push workflows can run."
@@ -211,7 +237,7 @@ jobs:
           fi
 
       - name: Record auto-merge evidence (APPROVE only)
-        if: steps.idempotency.outputs.skip != 'true' && steps.review.outputs.verdict == 'APPROVE'
+        if: steps.idempotency.outputs.skip != 'true' && steps.review.outputs.verdict == 'APPROVE' && steps.healing.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ steps.idempotency.outputs.head_sha }}
@@ -323,7 +349,7 @@ jobs:
           done
 
       - name: Dispatch repo-assist for next cycle
-        if: always() && steps.idempotency.outputs.skip != 'true' && steps.review.outputs.verdict != ''
+        if: always() && steps.idempotency.outputs.skip != 'true' && steps.review.outputs.verdict != '' && steps.healing.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVIEW_VERDICT: ${{ steps.review.outputs.verdict }}
@@ -372,13 +398,33 @@ jobs:
   # ---------------------------------------------------------------------------
   submit-review-dispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch'
 
     concurrency:
       group: "pr-review-submit-${{ github.event.inputs.pr_number }}"
       cancel-in-progress: false
 
+    env:
+      PIPELINE_HEALING_ENABLED: ${{ vars.PIPELINE_HEALING_ENABLED }}
+
     steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/healing-control.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Check healing pause switch
+        id: healing
+        run: |
+          if scripts/healing-control.sh is-enabled; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Autonomous healing is paused via PIPELINE_HEALING_ENABLED."
+          fi
+
       - name: Check idempotency (skip if same verdict already reviewed at current HEAD)
         id: idempotency
         env:
@@ -468,20 +514,28 @@ jobs:
             -f description="Review completed: ${VERDICT}"
           echo "Set 'review' status check to success on ${HEAD_SHA} (verdict: ${VERDICT})"
 
-      - name: Mark draft PR ready and enable auto-merge (APPROVE only)
+      - name: Mark draft PR ready (APPROVE only)
         if: always() && github.event.inputs.verdict == 'APPROVE'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_DRAFT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft -q '.isDraft')
+          if [ "$PR_DRAFT" = "true" ]; then
+            gh pr ready "$PR_NUMBER" --repo "$REPO" || echo "::warning::Could not mark PR as ready"
+          else
+            echo "PR #${PR_NUMBER} is already ready for review."
+          fi
+
+      - name: Enable auto-merge (APPROVE only)
+        if: always() && github.event.inputs.verdict == 'APPROVE' && steps.healing.outputs.enabled == 'true'
+        env:
           MERGE_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
           PR_TITLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq '.title')
-
-          PR_DRAFT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft -q '.isDraft')
-          if [ "$PR_DRAFT" = "true" ]; then
-            gh pr ready "$PR_NUMBER" --repo "$REPO" || echo "::warning::Could not mark PR as ready"
-          fi
 
           if [[ "$PR_TITLE" == "[Pipeline]"* ]]; then
             if [ -z "$MERGE_TOKEN" ]; then
@@ -495,7 +549,7 @@ jobs:
           fi
 
       - name: Record auto-merge evidence (APPROVE only)
-        if: always() && github.event.inputs.verdict == 'APPROVE'
+        if: always() && github.event.inputs.verdict == 'APPROVE' && steps.healing.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ steps.idempotency.outputs.head_sha }}
@@ -619,7 +673,7 @@ jobs:
           done
 
       - name: Dispatch repo-assist for next cycle
-        if: always()
+        if: always() && steps.healing.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVIEW_VERDICT: ${{ steps.review.outputs.verdict }}
@@ -660,3 +714,11 @@ jobs:
               echo "::warning::No linked issue found for PR #${PR_NUMBER} — cannot post /repo-assist"
             fi
           fi
+
+      - name: Log paused autonomous follow-up skip
+        if: always() && steps.healing.outputs.enabled != 'true'
+        run: echo "Review completed, but autonomous follow-up is paused via PIPELINE_HEALING_ENABLED."
+
+      - name: Log paused autonomous follow-up skip
+        if: always() && steps.idempotency.outputs.skip != 'true' && steps.review.outputs.verdict != '' && steps.healing.outputs.enabled != 'true'
+        run: echo "Review completed, but autonomous follow-up is paused via PIPELINE_HEALING_ENABLED."

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ git push
 - Delete branch on merge enabled
 - Active `Protect main` ruleset on `main`
 
+### Emergency Control
+
+Set repository variable `PIPELINE_HEALING_ENABLED=false` to pause autonomous
+healing. Review submission and failure detection still run, but auto-dispatch,
+watchdog remediation, repair-command posting, and pipeline auto-merge are
+skipped until the variable is unset or set back to `true`.
+
 ## How the Pipeline Works
 
 1. **Write a PRD** — paste it in a GitHub Issue

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,6 +197,8 @@ Safety mechanisms:
 - Skips all dispatches if repo-assist is already running (prevents flooding)
 - One action per cycle (stalled PR takes priority over orphaned issue)
 - Concurrency group `pipeline-watchdog` with `cancel-in-progress: false`
+- Honors repository variable `PIPELINE_HEALING_ENABLED=false` and exits without
+  taking write actions
 - Posts completion notice on status issue when all pipeline items are resolved
 
 ### ci-failure-issue
@@ -224,6 +226,19 @@ Fallback and escalation paths:
 - If the failure is on `main`, the PR is not a `[Pipeline]` PR, the PR has no linked
   issue, or repair dispatch fails, the workflow creates or updates a standalone
   `[CI Incident]` issue instead of silently dropping the event.
+- If `PIPELINE_HEALING_ENABLED=false`, failure detection still runs and incident
+  state is still recorded, but the router escalates instead of posting a repair
+  command or creating an auto-dispatchable pipeline bug issue.
+
+## Healing Pause Switch
+
+The repository-level variable `PIPELINE_HEALING_ENABLED` acts as the stop-the-
+bleeding control for the autonomous loop:
+
+- Reviews still happen, and the `review` status check is still written.
+- Failure detection still happens, and CI incidents are still recorded.
+- Autonomous remediation, repo-assist dispatch, repair-command reposts, and
+  pipeline PR auto-merge are paused when the variable is set to `false`.
 
 ### dotnet-ci
 

--- a/docs/SELF_HEALING_MVP.md
+++ b/docs/SELF_HEALING_MVP.md
@@ -33,6 +33,19 @@ with all of them in place:
 - `Protect main` requires the `review` status check
 - `Protect main` remains squash-only with admin bypass enabled
 
+## Healing Pause Switch
+
+Use repository variable `PIPELINE_HEALING_ENABLED` for the stop-the-bleeding
+control:
+
+- unset or `true`: autonomous healing stays enabled
+- `false`: review submission and failure detection still run, but autonomous
+  remediation and pipeline auto-merge are paused
+
+When paused, the workflows still record incident state and escalation evidence.
+They do not auto-dispatch `repo-assist`, repost repair commands, or arm
+pipeline PR auto-merge.
+
 ## Bootstrap Steps
 
 ```bash

--- a/scripts/healing-control.sh
+++ b/scripts/healing-control.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: healing-control.sh is-enabled" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || usage
+
+case "$1" in
+  is-enabled)
+    RAW_VALUE="${PIPELINE_HEALING_ENABLED:-}"
+    NORMALIZED_VALUE=$(printf '%s' "$RAW_VALUE" | tr '[:upper:]' '[:lower:]')
+
+    case "$NORMALIZED_VALUE" in
+      "")
+        exit 0
+        ;;
+      true)
+        exit 0
+        ;;
+      false)
+        exit 1
+        ;;
+      *)
+        echo "Invalid PIPELINE_HEALING_ENABLED value '${RAW_VALUE}'; expected true or false. Treating as disabled." >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/tests/test-healing-control.sh
+++ b/scripts/tests/test-healing-control.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/healing-control.sh"
+
+if ! env -u PIPELINE_HEALING_ENABLED "$SCRIPT" is-enabled; then
+  echo "FAIL: unset PIPELINE_HEALING_ENABLED should enable healing" >&2
+  exit 1
+fi
+
+if ! PIPELINE_HEALING_ENABLED=true "$SCRIPT" is-enabled; then
+  echo "FAIL: PIPELINE_HEALING_ENABLED=true should enable healing" >&2
+  exit 1
+fi
+
+if PIPELINE_HEALING_ENABLED=false "$SCRIPT" is-enabled; then
+  echo "FAIL: PIPELINE_HEALING_ENABLED=false should disable healing" >&2
+  exit 1
+fi
+
+INVALID_OUTPUT=$(PIPELINE_HEALING_ENABLED=maybe "$SCRIPT" is-enabled 2>&1 >/dev/null || true)
+if [ -z "$INVALID_OUTPUT" ]; then
+  echo "FAIL: invalid PIPELINE_HEALING_ENABLED value should emit an error" >&2
+  exit 1
+fi
+
+if PIPELINE_HEALING_ENABLED=maybe "$SCRIPT" is-enabled >/dev/null 2>&1; then
+  echo "FAIL: invalid PIPELINE_HEALING_ENABLED value should disable healing" >&2
+  exit 1
+fi
+
+echo "healing-control.sh tests passed"


### PR DESCRIPTION
Closes #323

## Summary
- add `PIPELINE_HEALING_ENABLED` handling via `scripts/healing-control.sh`
- gate autonomous remediation and pipeline auto-merge when healing is paused
- add explicit workflow timeouts and document the pause-switch behavior

## Testing
- `bash scripts/tests/test-healing-control.sh`
- `bash scripts/tests/test-verify-mvp.sh`
- `bash scripts/verify-mvp.sh --skip-audit`
- `bash scripts/verify-mvp.sh --audit-commit ff2f18746416dfb8ae8bfe1e414e031983a5fb73`