### PR TITLE
Clarify autonomy boundaries in operator docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,10 +10,10 @@ Product Requirements Documents (PRDs) into implemented code via AI agents:
    acceptance criteria
 3. **`repo-assist`** — AI picks up issues, writes code, opens draft PRs
 4. **`pr-review-agent`** — Agentic review posts a verdict comment (full context, no truncation)
-5. **`pr-review-submit`** — Submits the formal APPROVE/REQUEST_CHANGES review as `github-actions[bot]`
+5. **`pr-review-submit`** — Submits the formal APPROVE/REQUEST_CHANGES review as `github-actions[bot]` and auto-merges approved `[Pipeline]` PRs
 6. **`pipeline-status`** — Daily dashboard tracks progress
 
-Human role: write PRDs, review PRs, merge.
+Human role: write PRDs, review outcomes, and manually merge non-pipeline PRs.
 
 ## Repository Structure
 ```
@@ -69,7 +69,7 @@ The pipeline follows a **drop → run → tag → showcase → reset** cycle.
 | `repo-assist` | Daily + `/repo-assist` | Implements issues → opens PRs |
 | `pipeline-status` | Daily | Updates progress dashboard issue |
 | `pr-review-agent` | PR opened/updated | AI code review (full context) |
-| `pr-review-submit` | Verdict comment created | Submits formal review + auto-merge |
+| `pr-review-submit` | Verdict comment created | Submits formal review + auto-merge for approved `[Pipeline]` PRs |
 
 ## Pipeline Issue Lifecycle
 1. `prd-decomposer` creates issues with `[Pipeline]` prefix and `pipeline` label
@@ -79,9 +79,12 @@ The pipeline follows a **drop → run → tag → showcase → reset** cycle.
    (`repo-assist/issue-<N>-<desc>`), implements code, and opens draft PRs
 4. `pr-review-agent` reviews pipeline PRs with full context, posts a verdict comment
 5. `pr-review-submit` reads the verdict and submits the formal APPROVE/REQUEST_CHANGES review
-6. On approval, auto-merge is enabled; on merge, the linked issue auto-closes
-   via `Closes #N`
+6. On approval of a `[Pipeline]` PR, auto-merge is enabled; on merge, the linked
+   issue auto-closes via `Closes #N`
 7. `repo-assist` re-dispatches to pick up the next issue
+
+Human-authored PRs can still use the same review and CI workflows, but they
+are manually merged by default.
 
 ## PR Conventions
 - Title prefix: `[Pipeline]` for all agent-created PRs

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # PRD to Prod
 
-Drop a PRD, get a deployed app. Zero human code.
+Drop a PRD, get a deployed app. Autonomous on the pipeline-generated path.
 
-An autonomous software pipeline that decomposes product requirements into GitHub Issues, implements them as Pull Requests, reviews its own code, merges — and self-heals when things break. Powered by [gh-aw](https://github.com/github/gh-aw) agentic workflows.
+An autonomous software pipeline that decomposes product requirements into
+GitHub Issues, implements them as Pull Requests, reviews its own code,
+auto-merges approved `[Pipeline]` PRs, and self-heals common pipeline failures.
+Powered by [gh-aw](https://github.com/github/gh-aw) agentic workflows.
 
 ## What It Does
 
@@ -17,15 +20,17 @@ You write a product requirements document. The pipeline does everything else:
 - **Decomposes** the PRD into atomic, dependency-ordered issues
 - **Implements** each issue — branching, writing code, running tests, opening PRs
 - **Reviews** every PR with full-context AI code review (no truncation)
-- **Merges** approved PRs via squash merge, closing linked issues
-- **Self-heals** — a watchdog re-dispatches stalled work every 30 min, and CI failures auto-create bug issues that feed back into the pipeline
+- **Auto-merges** approved `[Pipeline]` PRs via squash merge, closing linked issues
+- **Self-heals** common pipeline failures — stalled pipeline PRs, CI incidents, orphaned issues, and duplicate cleanup
 - **Tracks progress** on a GitHub Projects v2 board, updated every run
 
-10 workflows. No human in the loop.
+For pipeline-generated work, the default path requires no human coding or merge
+intervention. Human-authored PRs, break-glass changes, and operator
+interventions remain manual by design.
 
 ## Shipped So Far
 
-Four complete apps built autonomously — zero human code written.
+Four complete apps built autonomously — zero human implementation code written.
 
 | Run | App | Stack | Tag |
 |-----|-----|-------|-----|
@@ -92,19 +97,37 @@ healing. Review submission and failure detection still run, but auto-dispatch,
 watchdog remediation, repair-command posting, and pipeline auto-merge are
 skipped until the variable is unset or set back to `true`.
 
+## Autonomy Boundaries
+
+The repo intentionally distinguishes between pipeline-generated PRs and
+human-authored PRs:
+
+- PRs titled `[Pipeline] ...` are the autonomous path. After approval, they can
+  be auto-merged by `pr-review-submit`.
+- Human-authored PRs still go through review and CI, but they are not
+  auto-merged by the pipeline.
+- "Self-healing" means the workflows can retry, redispatch, escalate, and
+  repair common pipeline incidents. It does not mean rollback automation or
+  automatic merging of arbitrary approved PRs.
+
 ## How the Pipeline Works
 
 1. **Write a PRD** — paste it in a GitHub Issue
 2. **`/decompose`** — AI breaks it into issues with acceptance criteria and dependency ordering
 3. **`repo-assist`** — AI implements each issue as a PR (branch, code, test, open)
 4. **`pr-review-agent`** — AI reviews the full diff against acceptance criteria
-5. **`pr-review-submit`** — formal review + squash merge + re-dispatch for the next issue
-6. **Self-healing** — watchdog catches stalls, CI failures become auto-fix issues
+5. **`pr-review-submit`** — formal review + auto-merge for approved `[Pipeline]`
+   PRs + re-dispatch for the next issue
+6. **Self-healing** — watchdog catches stalls, CI failures feed the repair loop,
+   and unresolved incidents escalate
 
-The loop runs until every issue from the PRD is shipped.
+The autonomous loop runs until every issue from the PRD is shipped. Human PRs
+can still use the same review workflows, but they remain outside the auto-merge
+path.
 
 For the full architecture, workflow details, design decisions, and self-healing mechanics, see [**docs/ARCHITECTURE.md**](docs/ARCHITECTURE.md).
 For the MVP setup, verification steps, and drill commands, see [**docs/SELF_HEALING_MVP.md**](docs/SELF_HEALING_MVP.md).
+For the rationale behind the gh-aw + GitHub Actions split, see [**docs/why-gh-aw.md**](docs/why-gh-aw.md).
 
 ## License
 

--- a/docs/SELF_HEALING_MVP.md
+++ b/docs/SELF_HEALING_MVP.md
@@ -9,6 +9,17 @@ This repository still contains profile-aware CI and deploy routing for Node and
 Docker, but the reproducible MVP claim in this runbook applies only to the
 current `.NET + Azure App Service` path.
 
+## Autonomy Boundary
+
+This MVP is autonomous only on the pipeline-generated path:
+
+- Approved `[Pipeline]` PRs can be auto-merged by `pr-review-submit`.
+- Human-authored PRs still run through review and CI, but they remain
+  manually merged by default.
+- "Self-healing" in this runbook means retry, redispatch, repair, escalation,
+  and cleanup of pipeline incidents. It does not mean rollback automation or
+  automatic merge of arbitrary approved PRs.
+
 ## Required Secrets
 
 Configure these repository secrets before using the autonomous loop:
@@ -110,6 +121,10 @@ For a passing audit or live drill, confirm all of the following evidence exists:
 - A successful main recovery run URL
 - A final drill JSON report under `drills/reports/`
 
+For an approved `[Pipeline]` PR, you may also see an `auto-merge-armed` status
+evidence marker before the merge completes. Human-authored PRs will not emit
+that status because they are not auto-merged by default.
+
 ## Known Limitations
 
 - There is no rollback automation.
@@ -117,6 +132,7 @@ For a passing audit or live drill, confirm all of the following evidence exists:
 - Week-one MVP support is not claimed for profiles other than `dotnet-azure`.
 - Watchdog and requeue behavior are mostly redispatch logic, not root-cause
   diagnosis.
+- Human-authored PRs are not auto-merged by the autonomous loop.
 
 ## Troubleshooting
 
@@ -174,6 +190,20 @@ Interpretation:
 - `direct`: auto-dispatch ran immediately.
 - `deferred`: repo-assist was already active, so dispatch was postponed.
 - `deferred->requeued`: the requeue workflow picked it up later.
+
+### Approved PR did not auto-merge
+
+Symptoms:
+
+- The PR shows `APPROVED`.
+- CI is green.
+- No merge happens automatically.
+
+Interpretation:
+
+- Only `[Pipeline]` PRs are auto-merged by the autonomous loop.
+- Human-authored PRs can use the same review workflows and status checks, but
+  they stay manual unless you intentionally change the merge policy.
 
 ### Local tests pass but GitHub audit fails
 

--- a/docs/why-gh-aw.md
+++ b/docs/why-gh-aw.md
@@ -72,12 +72,17 @@ This repo uses both. The split follows a simple rule: **deterministic logic stay
 | `copilot-setup-steps.yml` | Environment setup (install .NET SDK, gh-aw) |
 | `close-issues.yml` | Parse PR body for `Closes #N`, close linked issues |
 | `auto-dispatch.yml` | Debounce guard — check if repo-assist is already running, then dispatch |
-| `pr-review-submit.yml` | Parse `[PIPELINE-VERDICT]` comment, submit formal GH review, enable auto-merge, dispatch next cycle |
+| `pr-review-submit.yml` | Parse `[PIPELINE-VERDICT]` comment, submit formal GH review, enable auto-merge for approved `[Pipeline]` PRs, dispatch next cycle |
 | `ci-failure-issue.yml` | Extract failure logs, post `/repo-assist` repair command to linked issue |
 | `ci-failure-resolve.yml` | Update incident comment to "resolved" when CI passes after a failure |
 | `pipeline-watchdog.yml` | Cron stall detector — retry stuck repairs, escalate orphaned issues |
 
 These workflows are routing, guard logic, state transitions, and deployment. They follow fixed rules: if X then Y. No ambiguity, no judgment needed.
+
+This repo also keeps an explicit autonomy boundary: the autonomous merge path is
+restricted to pipeline-generated PRs whose titles start with `[Pipeline]`.
+Human-authored PRs can reuse the same CI and review workflows, but they are
+manually merged by default.
 
 ### gh-aw agentic workflows (LLM-powered)
 
@@ -98,7 +103,7 @@ The `.md` → `.lock.yml` pair is fundamental to gh-aw. You author in Markdown, 
 
 ### 1. It closes the "last mile" gap
 
-The industry has automated building, testing, and deploying for years. But writing code remained manual. gh-aw puts an agent in that gap — a design brief (GitHub issue) goes in, a working PR comes out. This pipeline chains that capability into a loop: decompose → implement → review → merge → repeat.
+The industry has automated building, testing, and deploying for years. But writing code remained manual. gh-aw puts an agent in that gap — a design brief (GitHub issue) goes in, a working PR comes out. This pipeline chains that capability into a loop: decompose → implement → review → auto-merge approved pipeline PRs → repeat.
 
 ### 2. Natural language becomes the interface
 

--- a/showcase/01-code-snippet-manager/README.md
+++ b/showcase/01-code-snippet-manager/README.md
@@ -8,8 +8,8 @@
 
 First end-to-end test of the agentic pipeline. A single `/decompose` command
 turned a Code Snippet Manager PRD into 8 atomic issues. The pipeline
-autonomously implemented all 8 as PRs, reviewed them with GPT-5, and
-squash-merged each one — zero human code written.
+autonomously implemented all 8 as pipeline PRs, reviewed them with GPT-5, and
+squash-merged each one — zero human implementation code written.
 
 ## Tech Stack
 

--- a/showcase/02-pipeline-observatory/README.md
+++ b/showcase/02-pipeline-observatory/README.md
@@ -10,8 +10,8 @@
 A Next.js 14 dashboard that visualizes the agentic pipeline itself — interactive
 simulator, timeline replay of real GitHub data, and forensic inspection of agent
 decisions and failure patterns. 10 features decomposed from the PRD, all
-autonomously implemented, reviewed, and merged. 32 Vitest tests. Deployed to
-Vercel.
+autonomously implemented, reviewed, and merged on the pipeline-generated path.
+32 Vitest tests. Deployed to Vercel.
 
 ## Tech Stack
 

--- a/showcase/03-devcard/README.md
+++ b/showcase/03-devcard/README.md
@@ -11,8 +11,8 @@ A developer identity card generator that fetches GitHub profile data and renders
 shareable, themed cards with language breakdowns, top repositories, and export
 options. Features a gallery of notable developers including Linus Torvalds, Dan
 Abramov, and Peter Steinberger (OpenClaw). 10 features decomposed from the PRD,
-all autonomously implemented, reviewed, and merged — plus 7 bug fixes filed and
-resolved in a follow-up session.
+all autonomously implemented, reviewed, and merged on the pipeline-generated
+path — plus 7 bug fixes filed and resolved in a follow-up session.
 
 ## Tech Stack
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -1,12 +1,16 @@
 # Showcase
 
 Each entry below is a PRD that was fed to the agentic pipeline and autonomously
-implemented — from issue decomposition through code review and merge.
+implemented on the pipeline-generated path — from issue decomposition through
+code review and pipeline PR merge.
+
+These showcase runs demonstrate the autonomous path. Human-authored PRs in this
+repo are still manually merged by design.
 
 The pipeline itself lives in `.github/`, `scripts/`, and `docs/`. The
 implementation code for each run is preserved at its git tag.
 
 | Run | PRD | Tech Stack | Tag | Highlights |
 |-----|-----|-----------|-----|------------|
-| 01 | [Code Snippet Manager](01-code-snippet-manager/) | Express + TypeScript | [`v1.0.0`](https://github.com/samuelkahessay/agentic-pipeline/tree/v1.0.0) | 8 features, 7 PRs, zero human code |
+| 01 | [Code Snippet Manager](01-code-snippet-manager/) | Express + TypeScript | [`v1.0.0`](https://github.com/samuelkahessay/agentic-pipeline/tree/v1.0.0) | 8 features, 7 PRs, zero human implementation code |
 | 02 | [Pipeline Observatory](02-pipeline-observatory/) | Next.js 14 + TypeScript | [`v2.0.0`](https://github.com/samuelkahessay/agentic-pipeline/tree/v2.0.0) | 10 features, 32 tests, live deployment |


### PR DESCRIPTION
## Summary
- clarify that only approved `[Pipeline]` PRs are auto-merged by the autonomous loop
- document that human-authored PRs still use review and CI but are merged manually
- tighten README, architecture, MVP runbook, contributor docs, and showcase wording so self-healing scope is described consistently

## Validation
- `git diff --check`

Closes #325