### PR TITLE
[Pipeline] Fix CS1002 build failure in DrillCanary.cs

### DIFF
--- a/TicketDeflection/Canary/DrillCanary.cs
+++ b/TicketDeflection/Canary/DrillCanary.cs
@@ -8,5 +8,5 @@ namespace TicketDeflection.Canary;
 /// </summary>
 public static class DrillCanary
 {
-    public static string Status() => "broken"
+    public static string Status() => "broken";
 }


### PR DESCRIPTION
Closes #327

## Summary

Restores the missing semicolon on line 11 of `TicketDeflection/Canary/DrillCanary.cs`, fixing the `CS1002: ; expected` build error introduced by the deliberate drill commit `fc96212`.

**Root cause:** The drill commit `drill(main_build_syntax): inject deliberate build failure [drill-id:20260302-152002]` removed the trailing semicolon from the expression-bodied `Status()` method.

**Fix:** Add the missing `;` back.

```diff
-    public static string Status() => "broken"
+    public static string Status() => "broken";
```

## Test Results

Build was verified locally (syntax fix only — no logic changes).

---

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22582569232)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22582569232, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22582569232 -->

<!-- gh-aw-workflow-id: repo-assist -->