### PR TITLE
[Pipeline] Default selection of a run on the landing page

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -505,6 +505,10 @@
                         });
                 });
             });
+
+            // Auto-select the latest run (first button, sorted descending) on page load
+            var defaultBtn = document.querySelector('.run-select-btn');
+            if (defaultBtn) defaultBtn.click();
         })();
         </script>
 


### PR DESCRIPTION
Closes #329

## Summary

The replay section on the landing page previously showed "No replay selected — choose a run above to begin." on load, requiring users to manually click a run button. This fix auto-selects the latest run (the first button, rendered in descending order) on page load so the replay content is immediately visible.

## Changes

- `TicketDeflection/Pages/Index.cshtml`: Added 3 lines of JavaScript at the end of the replay IIFE to programmatically click the first `.run-select-btn` after all event listeners are registered.

## Test Results

Local build/test blocked by proxy restriction on NuGet (api.nuget.org is blocked in the agent environment). The change is purely client-side JavaScript with no C# modifications — CI will validate on GitHub Actions where NuGet is accessible.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22590470009)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22590470009, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22590470009 -->

<!-- gh-aw-workflow-id: repo-assist -->