### PR TITLE
[Pipeline] Make headline accurate on landing page

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -162,7 +162,7 @@
             <h1 class="font-sans text-5xl sm:text-6xl font-bold text-white mb-4 leading-tight">
                 Drop a PRD.<br />Get a deployed app.
             </h1>
-            <p class="text-dim text-base mb-6">Zero human code.<span class="cursor-blink ml-1">█</span></p>
+            <p class="text-dim text-base mb-6">Human sets the intent. AI handles everything else.<span class="cursor-blink ml-1">█</span></p>
             <p class="text-sm leading-relaxed max-w-2xl mb-8" style="color: var(--text)">
                 <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="text-accent font-bold hover:underline">prd-to-prod</a> is an autonomous software pipeline powered by
                 <a href="https://github.com/github/gh-aw" target="_blank" rel="noopener noreferrer" class="text-accent font-bold hover:underline">gh-aw</a> (GitHub Agentic Workflows).


### PR DESCRIPTION
Closes #331

## Changes

Updates the hero headline subtitle on the landing page from `"Zero human code."` to `"Human sets the intent. AI handles everything else."` — a more accurate description of the human–AI collaboration model.

The change is a single-line edit in `TicketDeflection/Pages/Index.cshtml` (line 165).

## Test Results

```
Passed! - Failed: 0, Passed: 82, Skipped: 0, Total: 82
```

All 82 tests pass.

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22593163251)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22593163251, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22593163251 -->

<!-- gh-aw-workflow-id: repo-assist -->