### PR TITLE
[Pipeline] Rewrite public narrative from "autonomous app factory" to "policy-bounded AI execution system"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,65 @@
 # PRD to Prod
 
-Drop a PRD, get a deployed app. Autonomous on the pipeline-generated path.
+A policy-bounded AI execution system that turns product requirements into
+shipped code within explicit autonomy limits.
 
-An autonomous software pipeline that decomposes product requirements into
-GitHub Issues, implements them as Pull Requests, reviews its own code,
-auto-merges approved `[Pipeline]` PRs, and self-heals common pipeline failures.
+You define the intent and the policy. The pipeline executes within those bounds:
+decomposing requirements, writing code, reviewing PRs, and merging — without
+human coding or merge intervention on the pipeline-generated path. Control-plane
+changes and human-authored PRs always require human approval.
+
 Powered by [gh-aw](https://github.com/github/gh-aw) agentic workflows.
 
 ## What It Does
 
 ```
-  PRD ──> Issues ──> Code ──> Review ──> Merge ──> Ship
-                       ↑                              |
-                       +────── loop until done ────────+
+  Human:   PRD ──────────────────────────────────────────────────> Policy
+                                                                       |
+  AI:           Issues ──> Code ──> Review ──> Merge ──> Ship         |
+                    ↑                              |        |          |
+                    +────── loop until done ────────+        |          |
+                                                            v          |
+                                              control-plane PRs: human-required
 ```
 
-You write a product requirements document. The pipeline does everything else:
+You write a product requirements document. The pipeline executes within policy:
 
 - **Decomposes** the PRD into atomic, dependency-ordered issues
 - **Implements** each issue — branching, writing code, running tests, opening PRs
 - **Reviews** every PR with full-context AI code review (no truncation)
 - **Auto-merges** approved `[Pipeline]` PRs via squash merge, closing linked issues
-- **Self-heals** common pipeline failures — stalled pipeline PRs, CI incidents, orphaned issues, and duplicate cleanup
+- **Self-heals** within autonomous scope — stalled PRs, CI incidents, orphaned issues
 - **Tracks progress** on a GitHub Projects v2 board, updated every run
 
-For pipeline-generated work, the default path requires no human coding or merge
-intervention. Human-authored PRs, break-glass changes, and operator
-interventions remain manual by design.
+Where AI stops: `.github/workflows/`, agent configs, and `autonomy-policy.yml`
+are control-plane paths. PRs touching them trigger REQUEST_CHANGES from the
+review agent — those merges require human approval.
+
+## Autonomy Policy
+
+The repo ships a formal [`autonomy-policy.yml`](autonomy-policy.yml) that
+defines the boundary between autonomous and human-required actions.
+
+Key rules:
+- **Fail-closed default** — unknown or unclassified actions require human approval
+- **Merge gate** — PRs touching `.github/workflows/**`, `.github/agents/**`, or
+  `autonomy-policy.yml` always get REQUEST_CHANGES from pr-review-agent
+- **Auto-merge scope** — only `[Pipeline]`-prefixed PRs on approved code changes;
+  never control-plane changes, never human-authored PRs
+- **Healing scope** — watchdog and CI repair operate only on `[Pipeline]` work;
+  human PRs are never modified by the pipeline
+
+**Emergency stop:** Set repository variable `PIPELINE_HEALING_ENABLED=false` to
+pause autonomous healing. Review submission and failure detection still run, but
+auto-dispatch, repair commands, and pipeline auto-merge are skipped until the
+variable is unset or reset to `true`. See [autonomy-policy.yml](autonomy-policy.yml)
+for the full classification.
 
 ## Shipped So Far
 
-Four complete apps built autonomously — zero human implementation code written.
+The autonomous path has produced five runs across different tech stacks.
+Each row is evidence: issue links, PR links, and a tagged commit you can
+`git checkout` and inspect. Zero human implementation code.
 
 | Run | App | Stack | Tag |
 |-----|-----|-------|-----|
@@ -47,6 +76,7 @@ See [`showcase/`](showcase/) for detailed run reports.
 
 Week-one MVP support is currently validated for the `dotnet-azure` profile.
 See [docs/SELF_HEALING_MVP.md](docs/SELF_HEALING_MVP.md) for the operator runbook.
+See [autonomy-policy.yml](autonomy-policy.yml) for the full action classification.
 
 ```bash
 # 1. Clone
@@ -95,7 +125,8 @@ git push
 Set repository variable `PIPELINE_HEALING_ENABLED=false` to pause autonomous
 healing. Review submission and failure detection still run, but auto-dispatch,
 watchdog remediation, repair-command posting, and pipeline auto-merge are
-skipped until the variable is unset or set back to `true`.
+skipped until the variable is unset or set back to `true`. See
+[autonomy-policy.yml](autonomy-policy.yml) for what stays running.
 
 ## Autonomy Boundaries
 

--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -6,18 +6,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>prd-to-prod — autonomous software pipeline</title>
-    <meta name="description" content="Drop a PRD, get a deployed app. Zero human code. An autonomous GitHub pipeline that decomposes requirements, writes code, reviews its own work, and ships." />
+    <meta name="description" content="A policy-bounded AI execution system. You set the intent. The pipeline executes within defined autonomy limits: decompose, implement, review, merge." />
     <!-- OpenGraph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="prd-to-prod" />
     <meta property="og:url" content="https://prd-to-prod.azurewebsites.net" />
-    <meta property="og:title" content="prd-to-prod — Drop a PRD. Get a deployed app." />
-    <meta property="og:description" content="Autonomous software pipeline: AI decomposes requirements → writes code → reviews PRs → ships to main. Zero human code." />
+    <meta property="og:title" content="prd-to-prod — Policy-bounded AI execution" />
+    <meta property="og:description" content="You set the intent. The pipeline executes within policy: decomposes requirements, writes code, reviews PRs, merges to main. Control-plane changes require human approval." />
     <meta property="og:image" content="https://prd-to-prod.azurewebsites.net/og-image.png" />
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="prd-to-prod — Drop a PRD. Get a deployed app." />
-    <meta name="twitter:description" content="Autonomous software pipeline: AI decomposes requirements → writes code → reviews PRs → ships to main. Zero human code." />
+    <meta name="twitter:title" content="prd-to-prod — Policy-bounded AI execution" />
+    <meta name="twitter:description" content="You set the intent. The pipeline executes within policy: decomposes requirements, writes code, reviews PRs, merges to main. Control-plane changes require human approval." />
     <meta name="twitter:image" content="https://prd-to-prod.azurewebsites.net/og-image.png" />
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -158,17 +158,17 @@
 
         <!-- Hero -->
         <section class="mb-16">
-            <div class="text-xs text-dim mb-5">// autonomous software factory — powered by gh-aw</div>
+            <div class="text-xs text-dim mb-5">// autonomous execution engine — policy-bounded, powered by gh-aw</div>
             <h1 class="font-sans text-5xl sm:text-6xl font-bold text-white mb-4 leading-tight">
                 Drop a PRD.<br />Get a deployed app.
             </h1>
-            <p class="text-dim text-base mb-6">Human sets the intent. AI handles everything else.<span class="cursor-blink ml-1">█</span></p>
+            <p class="text-dim text-base mb-6">Human sets the intent. AI executes within bounds.<span class="cursor-blink ml-1">█</span></p>
             <p class="text-sm leading-relaxed max-w-2xl mb-8" style="color: var(--text)">
-                <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="text-accent font-bold hover:underline">prd-to-prod</a> is an autonomous software pipeline powered by
+                <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="text-accent font-bold hover:underline">prd-to-prod</a> is a policy-bounded AI execution system powered by
                 <a href="https://github.com/github/gh-aw" target="_blank" rel="noopener noreferrer" class="text-accent font-bold hover:underline">gh-aw</a> (GitHub Agentic Workflows).
                 It reads a product requirements document, decomposes it into GitHub Issues,
-                writes code for each one, opens Pull Requests, reviews its own work, merges to main —
-                and self-heals when things break. No human writes a single line of code.
+                writes code for each one, opens Pull Requests, reviews its own work, and merges to main —
+                within explicit autonomy limits. Control-plane changes always require human approval.
             </p>
             <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="exec-btn inline-block" style="text-decoration: none; display: inline-block;">[ View on GitHub ]</a>
         </section>
@@ -235,10 +235,20 @@
                         </div>
                     </div>
 
+                    <div class="divider"></div>
+
+                    <div class="flex gap-4 items-start">
+                        <span class="stage-label" style="background:rgba(245,166,35,0.12);color:var(--amber);border-color:rgba(245,166,35,0.3)">POLICY</span>
+                        <div>
+                            <div class="text-xs mb-1" style="color:var(--amber)">[ autonomy boundary ]</div>
+                            <div class="text-dim text-xs leading-relaxed">Control-plane paths (.github/workflows/, autonomy-policy.yml) require human review — the pipeline will REQUEST_CHANGES and not auto-merge. See <a href="https://github.com/samuelkahessay/prd-to-prod/blob/main/autonomy-policy.yml" target="_blank" rel="noopener noreferrer" class="hover:underline" style="color:var(--amber)">autonomy-policy.yml</a>.</div>
+                        </div>
+                    </div>
+
                 </div>
             </div>
             <div class="mt-3 text-xs text-dim">
-                <span class="text-accent">Self-healing:</span> pipeline-watchdog detects stalls, retries failures, cleans up superseded PRs. No human intervention required.
+                <span class="text-accent">Self-healing:</span> pipeline-watchdog detects stalls, retries failures, cleans up superseded PRs. Bounded to [Pipeline] work only.
             </div>
         </section>
 
@@ -519,7 +529,10 @@
                 <div class="text-dim mb-1">
                     REPO: <a href="https://github.com/samuelkahessay/prd-to-prod" class="text-accent hover:underline">github.com/samuelkahessay/prd-to-prod</a>
                 </div>
-                <div class="text-dim">Every issue, PR, review comment, and merge commit is public. The pipeline's git history is the source of truth.</div>
+                <div class="text-dim mb-1">Every issue, PR, review comment, and merge commit is public. The pipeline's git history is the source of truth.</div>
+                <div class="text-dim">
+                    POLICY: <a href="https://github.com/samuelkahessay/prd-to-prod/blob/main/autonomy-policy.yml" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">autonomy-policy.yml</a> — defines which actions the pipeline may take autonomously and which require human approval.
+                </div>
             </div>
         </section>
 

--- a/autonomy-policy.yml
+++ b/autonomy-policy.yml
@@ -1,0 +1,92 @@
+version: 1
+description: >
+  Autonomy policy for the prd-to-prod pipeline. Defines which actions the
+  pipeline may take autonomously and which require human approval.
+  Fail-closed: unknown actions default to human_required.
+
+defaults:
+  unknown_action: human_required
+
+# Paths that constitute control-plane changes — always require human review
+control_plane_paths:
+  - .github/workflows/**
+  - .github/agents/**
+  - autonomy-policy.yml
+
+actions:
+  - name: decompose_prd
+    classification: autonomous
+    description: >
+      prd-decomposer reads a PRD and creates [Pipeline] issues with acceptance
+      criteria and dependency ordering.
+
+  - name: implement_issue
+    classification: autonomous
+    description: >
+      repo-assist creates a branch from main, writes code, opens a draft PR
+      with Closes #N referencing the source issue.
+
+  - name: review_pr
+    classification: autonomous
+    description: >
+      pr-review-agent reads the full PR diff and linked issue acceptance
+      criteria, then posts a [PIPELINE-VERDICT] comment.
+
+  - name: merge_pipeline_pr
+    classification: autonomous
+    when: "[Pipeline] PR approved by pr-review-agent with passing CI"
+    description: >
+      pr-review-submit enables squash auto-merge for approved [Pipeline] PRs.
+      Human-authored PRs are never auto-merged.
+
+  - name: close_linked_issue
+    classification: autonomous
+    when: "Merged PR body contains Closes #N"
+    description: >
+      close-issues workflow closes the linked issue after PR merge.
+
+  - name: self_heal
+    classification: autonomous
+    description: >
+      pipeline-watchdog retries stalled pipeline PRs, dispatches repo-assist
+      for orphaned issues, and posts CI repair commands for failed builds.
+
+  - name: modify_workflows
+    classification: human_required
+    paths:
+      - .github/workflows/**
+      - .github/agents/**
+    description: >
+      Changes to pipeline workflows or agent configs require human review
+      and approval. The pipeline will REQUEST_CHANGES on any PR touching
+      these paths.
+
+  - name: merge_human_pr
+    classification: human_required
+    description: >
+      Human-authored PRs (no [Pipeline] prefix) are never auto-merged by
+      the pipeline regardless of review outcome.
+
+  - name: delete_production_branch
+    classification: human_required
+    description: >
+      Deletion of main or protected branches requires human authorization.
+
+merge_gate:
+  description: >
+    PRs touching control_plane_paths trigger REQUEST_CHANGES from
+    pr-review-agent unless explicitly authorized.
+  control_plane_paths:
+    - .github/workflows/**
+    - .github/agents/**
+    - autonomy-policy.yml
+  policy: request_changes
+
+healing_pause:
+  env_var: PIPELINE_HEALING_ENABLED
+  default: enabled
+  description: >
+    Set the PIPELINE_HEALING_ENABLED repository variable to false to pause
+    autonomous healing. Review submission and failure detection still run,
+    but auto-dispatch, watchdog remediation, CI repair-command posting, and
+    pipeline auto-merge are skipped until the variable is unset or reset to true.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,10 +1,28 @@
 # Architecture
 
+## System Model
+
+prd-to-prod is a policy-bounded AI execution system. Four layers define how it
+works and where AI authority stops:
+
+```
+  Layer 1 — Intent      Human writes the PRD and sets the autonomy policy
+  Layer 2 — Execution   AI implements: decomposes, codes, reviews, merges
+  Layer 3 — Policy      autonomy-policy.yml classifies actions as autonomous
+                        or human_required; fail-closed for unknowns
+  Layer 4 — Oversight   Merge gate blocks control-plane PRs; healing pause
+                        switch halts autonomous actions instantly
+```
+
+The pipeline operates entirely within Layer 2 unless constrained by Layers 3
+and 4. Human intervention is required for the PRD (Layer 1) and for any
+control-plane change (Layers 3/4).
+
 ## Pipeline Overview
 
-The agentic pipeline turns Product Requirements Documents (PRDs) into shipped code
-with minimal human intervention on the pipeline-generated path. Ten workflows
-cooperate in a loop:
+The agentic pipeline turns Product Requirements Documents (PRDs) into shipped
+code within the bounds set by the autonomy policy. Ten workflows cooperate
+in a loop:
 
 ```
  You write a PRD
@@ -50,6 +68,8 @@ cooperate in a loop:
 
 ## Workflows
 
+Each workflow is classified by its autonomy-policy action type.
+
 ### prd-decomposer
 
 | | |
@@ -58,6 +78,7 @@ cooperate in a loop:
 | **Engine** | Copilot (gpt-5) |
 | **Trigger** | `/decompose` command on an issue |
 | **Output** | Up to 20 atomic GitHub Issues with `[Pipeline]` prefix, acceptance criteria, and dependency ordering |
+| **Autonomy policy** | `decompose_prd` — **autonomous** |
 
 Reads a PRD from the issue body, decomposes it into implementable issues labeled
 `pipeline` + a type label (`feature`, `infra`, `test`, `docs`, `bug`). Issues
@@ -72,6 +93,7 @@ all issues, dispatches `repo-assist` once.
 | **Engine** | Copilot (gpt-5) |
 | **Trigger** | Dispatch from prd-decomposer or pr-review-submit, daily schedule, `/repo-assist` command |
 | **Output** | Up to 4 PRs per run |
+| **Autonomy policy** | `implement_issue` — **autonomous** (code changes); `modify_workflows` — **human_required** (control-plane paths blocked) |
 
 Runs a 5-task cycle each invocation:
 
@@ -96,6 +118,7 @@ The PR reviewer is split into two workflows to preserve **identity separation**:
 | **Engine** | Copilot (gpt-5) — full 64K-128K+ context window |
 | **Trigger** | Automatic on PR opened/updated/ready; `workflow_dispatch` |
 | **Output** | Verdict comment on the PR (starting with `[PIPELINE-VERDICT]`) |
+| **Autonomy policy** | `review_pr` — **autonomous**; issues REQUEST_CHANGES for control-plane path changes |
 
 Agentic workflow that runs as the Copilot app identity. Reads the **full PR diff**
 (no truncation), linked issue acceptance criteria, CI status, and AGENTS.md. Posts
@@ -127,6 +150,7 @@ Decision rules:
 | **Engine** | Standard GitHub Actions (`github-actions[bot]`) |
 | **Trigger** | `issue_comment: created` — fires when pr-review-agent posts its verdict |
 | **Output** | Formal APPROVE or REQUEST_CHANGES GitHub review; auto-merge for approved `[Pipeline]` PRs; repo-assist dispatch |
+| **Autonomy policy** | `merge_pipeline_pr` — **autonomous** for `[Pipeline]` PRs; `merge_human_pr` — **human_required** |
 
 Standard workflow that runs as `github-actions[bot]`. Watches for comments containing
 `[PIPELINE-VERDICT]` on PRs, parses the verdict, and submits the formal GitHub
@@ -171,6 +195,7 @@ issue with a summary table.
 | **Engine** | Standard GitHub Actions |
 | **Trigger** | `pull_request: closed` (merged only) |
 | **Output** | Closes linked issues via `gh issue close` |
+| **Autonomy policy** | `close_linked_issue` — **autonomous** |
 
 Dedicated workflow for closing issues referenced by `Closes #N` (and variants) in
 merged PR bodies. Isolated from pr-review-submit with its own concurrency group
@@ -188,6 +213,7 @@ to avoid script injection vulnerabilities.
 | **Engine** | Standard GitHub Actions |
 | **Trigger** | Cron (every 30 minutes), manual dispatch |
 | **Output** | `/repo-assist` comments, repo-assist dispatches, and escalation/cleanup actions |
+| **Autonomy policy** | `self_heal` — **autonomous** (scoped to `[Pipeline]` work only) |
 
 Cron-based stall detector that replaces the human supervisor. The current
 implementation scans four classes of problems each cycle:
@@ -334,6 +360,44 @@ pr-review-agent (Copilot identity) posts only a verdict comment; pr-review-submi
 **Re-dispatch loop** — After each merge, pr-review-submit checks for remaining open
 issues and re-dispatches repo-assist. This creates a continuous loop that runs
 until all issues from the PRD are implemented.
+
+## Policy Enforcement
+
+The autonomy policy ([`autonomy-policy.yml`](../autonomy-policy.yml)) governs
+what the pipeline can do without human approval.
+
+### Merge Gate
+
+PRs touching `.github/workflows/**`, `.github/agents/**`, or
+`autonomy-policy.yml` are classified as control-plane changes. pr-review-agent
+issues REQUEST_CHANGES for any such PR, requiring human review before merge.
+This prevents the pipeline from modifying its own decision-making authority.
+
+### Intake Classification
+
+Each action the pipeline takes is classified at intake:
+- **autonomous** — pr-review-submit can approve and auto-merge `[Pipeline]` PRs
+- **human_required** — the action requires a human review before proceeding
+- **unknown** — defaults to `human_required` (fail-closed)
+
+### Fail-Closed Defaults
+
+If an action is not explicitly listed in `autonomy-policy.yml`, it defaults to
+`human_required`. This prevents unknown capabilities from being silently
+exercised as the pipeline evolves.
+
+### Self-Healing Loops
+
+The pipeline's self-healing scope (`self_heal` action) is explicitly bounded to
+`[Pipeline]`-prefixed work. The watchdog will not modify human-authored PRs,
+close human issues, or dispatch repairs outside the pipeline's own backlog.
+
+### Healing Pause Switch
+
+Set `PIPELINE_HEALING_ENABLED=false` in repository variables to halt all
+autonomous healing instantly. Review submission and CI failure detection
+continue running, but no autonomous actions are triggered until the variable
+is unset or reset to `true`.
 
 ## Secrets
 


### PR DESCRIPTION
Closes #333

## Changes

Rewrites all three public-facing surfaces — README, architecture doc, and landing page — to lead with policy-bounded execution. Also creates `autonomy-policy.yml` as the formal policy artifact referenced by this and subsequent issues.

### New file: `autonomy-policy.yml`

Defines the autonomy boundary for the pipeline:
- **Fail-closed default**: unknown actions require human approval
- **Merge gate**: PRs touching `.github/workflows/**`, `.github/agents/**`, or `autonomy-policy.yml` get REQUEST_CHANGES
- **Action classifications**: `decompose_prd`, `implement_issue`, `review_pr`, `merge_pipeline_pr`, `close_linked_issue`, `self_heal` → autonomous; `modify_workflows`, `merge_human_pr`, `delete_production_branch` → human_required
- **Healing pause switch**: `PIPELINE_HEALING_ENABLED=false` halts all autonomous actions

### README.md

- New lead paragraph: "A policy-bounded AI execution system that turns product requirements into shipped code within explicit autonomy limits"
- New system diagram showing where AI stops (control-plane = human-required)
- New **Autonomy Policy** section above Quick Start explaining the policy file, merge-gate, and fail-closed defaults
- Emergency stop contextualized under policy (with link to autonomy-policy.yml)
- Run table reframed as evidence, not headline

### docs/ARCHITECTURE.md

- New **System Model** section opens the doc with the four-layer model: Intent → Execution → Policy → Oversight
- Each workflow entry now includes `Autonomy policy:` classification row
- New **Policy Enforcement** section covering merge gate, intake classification, fail-closed defaults, self-healing scope, and healing pause switch

### TicketDeflection/Pages/Index.cshtml

- Hero label: `// autonomous software factory` → `// autonomous execution engine — policy-bounded`
- Subtitle: "AI handles everything else" → "AI executes within bounds"
- Hero description updated to mention explicit autonomy limits and control-plane human approval
- Pipeline schematic: new **POLICY** stage row (amber color, constraint style) with link to autonomy-policy.yml
- Self-healing note: "No human intervention required" → "Bounded to [Pipeline] work only"
- Provenance section: added POLICY row linking to autonomy-policy.yml
- All existing navigation, aesthetics, run history, replay section, and demo button preserved

## Test Results

```
Passed! - Failed: 0, Passed: 82, Skipped: 0, Total: 82
```

All 82 tests pass. No `.github/workflows/` files modified.

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22597004332)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22597004332, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22597004332 -->

<!-- gh-aw-workflow-id: repo-assist -->