### PR TITLE
[Pipeline] Build backend autonomy APIs for decisions, queue, and metrics

### DIFF
--- a/TicketDeflection.Tests/AutonomyEndpointTests.cs
+++ b/TicketDeflection.Tests/AutonomyEndpointTests.cs
@@ -1,0 +1,280 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using TicketDeflection.DTOs;
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Tests;
+
+public class AutonomyEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public AutonomyEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    private HttpClient CreateClientWithLedger(string tempDir)
+    {
+        return _factory.WithWebHostBuilder(b =>
+        {
+            b.ConfigureServices(services =>
+            {
+                // Replace the singleton ledger service with one pointing at our temp dir.
+                var existing = services.SingleOrDefault(d => d.ServiceType == typeof(AutonomyLedgerService));
+                if (existing != null) services.Remove(existing);
+                services.AddSingleton(new AutonomyLedgerService(tempDir));
+            });
+        }).CreateClient();
+    }
+
+    [Fact]
+    public async Task Decisions_ReturnsOk_WhenNoLedger()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/autonomy/decisions");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Decisions_ReturnsEventsNewestFirst()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tmpDir);
+        try
+        {
+            var ledgerJson = """
+                [
+                  {"action":"merge_pipeline_pr","classification":"autonomous","timestamp":"2026-01-01T10:00:00Z","outcome":"acted","reason":null},
+                  {"action":"modify_workflows","classification":"human_required","timestamp":"2026-01-02T12:00:00Z","outcome":"queued","reason":null}
+                ]
+                """;
+            File.WriteAllText(Path.Combine(tmpDir, "ledger.json"), ledgerJson);
+
+            var client = CreateClientWithLedger(tmpDir);
+            var response = await client.GetAsync("/api/autonomy/decisions");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            var events = doc.RootElement.GetProperty("events").EnumerateArray().ToList();
+            Assert.Equal(2, events.Count);
+            // Newest first: Jan 2 should come before Jan 1
+            Assert.Contains("modify_workflows", events[0].GetProperty("action").GetString());
+        }
+        finally
+        {
+            Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Queue_ReturnsSeparateBuckets()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tmpDir);
+        try
+        {
+            var ledgerJson = """
+                [
+                  {"action":"merge_pipeline_pr","classification":"autonomous","timestamp":"2026-01-01T10:00:00Z","outcome":"acted","reason":null},
+                  {"action":"modify_workflows","classification":"human_required","timestamp":"2026-01-02T12:00:00Z","outcome":"queued","reason":null},
+                  {"action":"create_issue","classification":"autonomous","timestamp":"2026-01-03T08:00:00Z","outcome":"blocked","reason":"policy"}
+                ]
+                """;
+            File.WriteAllText(Path.Combine(tmpDir, "ledger.json"), ledgerJson);
+
+            var client = CreateClientWithLedger(tmpDir);
+            var response = await client.GetAsync("/api/autonomy/queue");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            Assert.True(doc.RootElement.TryGetProperty("blocked", out var blocked));
+            Assert.True(doc.RootElement.TryGetProperty("queuedForHuman", out var queued));
+            Assert.True(doc.RootElement.TryGetProperty("recentAutonomous", out var autonomous));
+            Assert.Equal(1, blocked.GetArrayLength());
+            Assert.Equal(1, queued.GetArrayLength());
+            Assert.Equal(1, autonomous.GetArrayLength());
+        }
+        finally
+        {
+            Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Metrics_ReturnsAggregatedCounts()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tmpDir);
+        try
+        {
+            var ledgerJson = """
+                [
+                  {"action":"merge_pipeline_pr","classification":"autonomous","timestamp":"2026-01-01T10:00:00Z","outcome":"acted","reason":null},
+                  {"action":"modify_workflows","classification":"human_required","timestamp":"2026-01-02T12:00:00Z","outcome":"queued","reason":null},
+                  {"action":"create_issue","classification":"autonomous","timestamp":"2026-01-03T08:00:00Z","outcome":"escalated","reason":"policy"}
+                ]
+                """;
+            File.WriteAllText(Path.Combine(tmpDir, "ledger.json"), ledgerJson);
+
+            var client = CreateClientWithLedger(tmpDir);
+            var response = await client.GetAsync("/api/autonomy/metrics");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            Assert.Equal(3, doc.RootElement.GetProperty("totalEvents").GetInt32());
+            Assert.Equal(1, doc.RootElement.GetProperty("autonomousActed").GetInt32());
+            Assert.Equal(0, doc.RootElement.GetProperty("blocked").GetInt32());
+            Assert.Equal(1, doc.RootElement.GetProperty("queuedForHuman").GetInt32());
+            Assert.Equal(1, doc.RootElement.GetProperty("escalated").GetInt32());
+            Assert.True(doc.RootElement.TryGetProperty("lastUpdated", out _));
+        }
+        finally
+        {
+            Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Metrics_ReturnsEmpty_WhenNoLedger()
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        // Don't create the dir — simulate missing ledger
+        try
+        {
+            var client = CreateClientWithLedger(tmpDir);
+            var response = await client.GetAsync("/api/autonomy/metrics");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            Assert.Equal(0, doc.RootElement.GetProperty("totalEvents").GetInt32());
+            Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("lastUpdated").ValueKind);
+        }
+        finally
+        {
+            if (Directory.Exists(tmpDir)) Directory.Delete(tmpDir, recursive: true);
+        }
+    }
+}
+
+public class AutonomyLedgerServiceTests
+{
+    private string CreateTempDir() => Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+    [Fact]
+    public void GetAllEvents_ReturnsEmpty_WhenNoDirExists()
+    {
+        var svc = new AutonomyLedgerService("/nonexistent/path");
+        Assert.Empty(svc.GetAllEvents());
+    }
+
+    [Fact]
+    public void GetAllEvents_ParsesArrayFile()
+    {
+        var dir = CreateTempDir();
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "ledger.json"), """
+                [{"action":"a","classification":"autonomous","timestamp":"2026-01-01T00:00:00Z","outcome":null,"reason":null}]
+                """);
+            var svc = new AutonomyLedgerService(dir);
+            var events = svc.GetAllEvents();
+            Assert.Single(events);
+            Assert.Equal("a", events[0].Action);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void GetAllEvents_ParsesSingleObjectFile()
+    {
+        var dir = CreateTempDir();
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "event.json"), """
+                {"action":"b","classification":"human_required","timestamp":"2026-01-02T00:00:00Z","outcome":"queued","reason":"policy"}
+                """);
+            var svc = new AutonomyLedgerService(dir);
+            var events = svc.GetAllEvents();
+            Assert.Single(events);
+            Assert.Equal("human_required", events[0].Classification);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void GetAllEvents_SkipsMalformedFiles()
+    {
+        var dir = CreateTempDir();
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "bad.json"), "not json {{{");
+            File.WriteAllText(Path.Combine(dir, "good.json"), """
+                [{"action":"c","classification":"autonomous","timestamp":"2026-01-03T00:00:00Z","outcome":"acted","reason":null}]
+                """);
+            var svc = new AutonomyLedgerService(dir);
+            var events = svc.GetAllEvents();
+            Assert.Single(events);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void GetQueue_GroupsCorrectly()
+    {
+        var dir = CreateTempDir();
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "ledger.json"), """
+                [
+                  {"action":"x","classification":"autonomous","timestamp":"2026-01-01T00:00:00Z","outcome":"acted","reason":null},
+                  {"action":"y","classification":"human_required","timestamp":"2026-01-02T00:00:00Z","outcome":"queued","reason":null},
+                  {"action":"z","classification":"autonomous","timestamp":"2026-01-03T00:00:00Z","outcome":"blocked","reason":"gate"}
+                ]
+                """);
+            var svc = new AutonomyLedgerService(dir);
+            var q = svc.GetQueue();
+            Assert.Single(q.Blocked);
+            Assert.Single(q.QueuedForHuman);
+            Assert.Single(q.RecentAutonomous);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void GetMetrics_AggregatesCorrectly()
+    {
+        var dir = CreateTempDir();
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "ledger.json"), """
+                [
+                  {"action":"a","classification":"autonomous","timestamp":"2026-01-01T00:00:00Z","outcome":"acted","reason":null},
+                  {"action":"b","classification":"human_required","timestamp":"2026-01-02T00:00:00Z","outcome":"queued","reason":null},
+                  {"action":"c","classification":"autonomous","timestamp":"2026-01-03T00:00:00Z","outcome":"escalated","reason":null}
+                ]
+                """);
+            var svc = new AutonomyLedgerService(dir);
+            var m = svc.GetMetrics();
+            Assert.Equal(3, m.TotalEvents);
+            Assert.Equal(1, m.AutonomousActed);
+            Assert.Equal(0, m.Blocked);
+            Assert.Equal(1, m.QueuedForHuman);
+            Assert.Equal(1, m.Escalated);
+            Assert.NotNull(m.LastUpdated);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/TicketDeflection/DTOs/AutonomyDtos.cs
+++ b/TicketDeflection/DTOs/AutonomyDtos.cs
@@ -1,0 +1,32 @@
+namespace TicketDeflection.DTOs;
+
+/// <summary>A single event recorded in the decision ledger.</summary>
+public record LedgerEvent(
+    string Action,
+    string Classification,
+    DateTime Timestamp,
+    string? Outcome,
+    string? Reason
+);
+
+/// <summary>Response for GET /api/autonomy/decisions — ledger events newest-first.</summary>
+public record DecisionsResponse(
+    IReadOnlyList<LedgerEvent> Events
+);
+
+/// <summary>Response for GET /api/autonomy/queue — operator action buckets.</summary>
+public record QueueResponse(
+    IReadOnlyList<LedgerEvent> Blocked,
+    IReadOnlyList<LedgerEvent> QueuedForHuman,
+    IReadOnlyList<LedgerEvent> RecentAutonomous
+);
+
+/// <summary>Response for GET /api/autonomy/metrics — aggregated counts.</summary>
+public record MetricsResponse(
+    int TotalEvents,
+    int AutonomousActed,
+    int Blocked,
+    int QueuedForHuman,
+    int Escalated,
+    DateTime? LastUpdated
+);

--- a/TicketDeflection/Endpoints/AutonomyEndpoints.cs
+++ b/TicketDeflection/Endpoints/AutonomyEndpoints.cs
@@ -1,0 +1,31 @@
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Endpoints;
+
+public static class AutonomyEndpoints
+{
+    public static void MapAutonomyEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/autonomy/decisions", GetDecisions);
+        app.MapGet("/api/autonomy/queue",     GetQueue);
+        app.MapGet("/api/autonomy/metrics",   GetMetrics);
+    }
+
+    private static IResult GetDecisions(AutonomyLedgerService ledger)
+    {
+        var events = ledger.GetAllEvents();
+        return Results.Ok(new { events });
+    }
+
+    private static IResult GetQueue(AutonomyLedgerService ledger)
+    {
+        var queue = ledger.GetQueue();
+        return Results.Ok(queue);
+    }
+
+    private static IResult GetMetrics(AutonomyLedgerService ledger)
+    {
+        var metrics = ledger.GetMetrics();
+        return Results.Ok(metrics);
+    }
+}

--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -11,6 +11,7 @@ builder.Services.AddScoped<ClassificationService>();
 builder.Services.AddScoped<MatchingService>();
 builder.Services.AddScoped<PipelineService>();
 builder.Services.AddSingleton<IShowcaseService, ShowcaseService>();
+builder.Services.AddSingleton<AutonomyLedgerService>();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
@@ -45,6 +46,7 @@ app.MapTicketEndpoints();
 app.MapKnowledgeEndpoints();
 app.MapClassifyEndpoints();
 app.MapResolveEndpoints();
+app.MapAutonomyEndpoints();
 
 app.MapGet("/health", () => Results.Ok(new { status = "healthy", version = "1.0.0" }));
 

--- a/TicketDeflection/Services/AutonomyLedgerService.cs
+++ b/TicketDeflection/Services/AutonomyLedgerService.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using TicketDeflection.DTOs;
+
+namespace TicketDeflection.Services;
+
+/// <summary>
+/// Loads and parses decision-ledger JSON files from the drills/reports directory.
+/// Returns an empty list when no ledger files are found.
+/// </summary>
+public class AutonomyLedgerService
+{
+    private readonly string _reportsDirectory;
+
+    public AutonomyLedgerService(string? reportsDirectory = null)
+    {
+        // Default to drills/reports relative to the application's content root.
+        _reportsDirectory = reportsDirectory
+            ?? Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "drills", "reports");
+    }
+
+    /// <summary>Returns all ledger events sorted newest-first.</summary>
+    public IReadOnlyList<LedgerEvent> GetAllEvents()
+    {
+        var events = LoadEvents();
+        return events.OrderByDescending(e => e.Timestamp).ToList();
+    }
+
+    /// <summary>Returns the operator queue with blocked, human-required, and autonomous buckets.</summary>
+    public QueueResponse GetQueue()
+    {
+        var all = GetAllEvents();
+        var blocked = all.Where(e => IsBlocked(e)).ToList();
+        var humanQueue = all.Where(e => IsQueuedForHuman(e)).ToList();
+        var autonomous = all.Where(e => IsAutonomousActed(e)).ToList();
+        return new QueueResponse(blocked, humanQueue, autonomous);
+    }
+
+    /// <summary>Returns aggregate metrics from all ledger events.</summary>
+    public MetricsResponse GetMetrics()
+    {
+        var all = LoadEvents();
+        var total = all.Count;
+        var autonomousActed = all.Count(IsAutonomousActed);
+        var blocked = all.Count(IsBlocked);
+        var humanQueue = all.Count(IsQueuedForHuman);
+        var escalated = all.Count(e =>
+            string.Equals(e.Outcome, "escalated", StringComparison.OrdinalIgnoreCase));
+        var lastUpdated = all.Count > 0
+            ? (DateTime?)all.Max(e => e.Timestamp)
+            : null;
+        return new MetricsResponse(total, autonomousActed, blocked, humanQueue, escalated, lastUpdated);
+    }
+
+    // --- private helpers ---
+
+    private List<LedgerEvent> LoadEvents()
+    {
+        var events = new List<LedgerEvent>();
+        if (!Directory.Exists(_reportsDirectory))
+            return events;
+
+        foreach (var file in Directory.EnumerateFiles(_reportsDirectory, "*.json"))
+        {
+            try
+            {
+                var text = File.ReadAllText(file);
+                var parsed = ParseLedgerFile(text);
+                events.AddRange(parsed);
+            }
+            catch (Exception)
+            {
+                // Skip malformed files silently — fail-open for reads.
+            }
+        }
+
+        return events;
+    }
+
+    private static IEnumerable<LedgerEvent> ParseLedgerFile(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        // Support both array-of-events and single-event shapes.
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            return root.EnumerateArray().Select(ParseSingleEvent).ToList();
+        }
+
+        if (root.ValueKind == JsonValueKind.Object)
+        {
+            // If the object has an "events" array, use that.
+            if (root.TryGetProperty("events", out var eventsEl) && eventsEl.ValueKind == JsonValueKind.Array)
+                return eventsEl.EnumerateArray().Select(ParseSingleEvent).ToList();
+
+            // Otherwise treat the object itself as a single event.
+            return new[] { ParseSingleEvent(root) };
+        }
+
+        return Enumerable.Empty<LedgerEvent>();
+    }
+
+    private static LedgerEvent ParseSingleEvent(JsonElement el)
+    {
+        var action = el.TryGetProperty("action", out var a) ? a.GetString() ?? "" : "";
+        var classification = el.TryGetProperty("classification", out var c) ? c.GetString() ?? "" : "";
+        var outcome = el.TryGetProperty("outcome", out var o) ? o.GetString() : null;
+        var reason = el.TryGetProperty("reason", out var r) ? r.GetString() : null;
+
+        DateTime timestamp = DateTime.UtcNow;
+        if (el.TryGetProperty("timestamp", out var ts) && ts.ValueKind == JsonValueKind.String)
+            DateTime.TryParse(ts.GetString(), out timestamp);
+
+        return new LedgerEvent(action, classification, timestamp, outcome, reason);
+    }
+
+    private static bool IsBlocked(LedgerEvent e) =>
+        string.Equals(e.Outcome, "blocked", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(e.Classification, "blocked", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsQueuedForHuman(LedgerEvent e) =>
+        string.Equals(e.Classification, "human_required", StringComparison.OrdinalIgnoreCase) &&
+        !IsBlocked(e);
+
+    private static bool IsAutonomousActed(LedgerEvent e) =>
+        string.Equals(e.Classification, "autonomous", StringComparison.OrdinalIgnoreCase) &&
+        !IsBlocked(e) &&
+        !string.Equals(e.Outcome, "escalated", StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(e.Outcome, "queued", StringComparison.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
Closes #335

## Changes

Backend-only. No Razor page UI, no workflow files modified, no autonomy-policy.yml changes.

### New: `TicketDeflection/DTOs/AutonomyDtos.cs`

Four record types:
- `LedgerEvent` — single ledger event (action, classification, timestamp, outcome, reason)
- `DecisionsResponse` — list of events for the decisions endpoint
- `QueueResponse` — three operator buckets: `Blocked`, `QueuedForHuman`, `RecentAutonomous`
- `MetricsResponse` — aggregate counts plus optional `LastUpdated` timestamp

### New: `TicketDeflection/Services/AutonomyLedgerService.cs`

Reads JSON files from `drills/reports/` and exposes three query methods:

| Method | Returns |
|--------|---------|
| `GetAllEvents()` | All events sorted newest-first |
| `GetQueue()` | Events grouped into blocked / human-required / autonomous-acted buckets |
| `GetMetrics()` | Aggregate counts: total, autonomousActed, blocked, queuedForHuman, escalated, lastUpdated |

Parsing handles three JSON shapes: array-of-events, `{"events": [...]}` wrapper, and single-object files. Malformed files are silently skipped. Missing ledger directory returns empty (fail-open for reads, fail-closed for policy enforcement).

Classification logic:
- **blocked**: `outcome=blocked` OR `classification=blocked`
- **queuedForHuman**: `classification=human_required` AND not blocked
- **autonomousActed**: `classification=autonomous` AND not blocked AND outcome is not `escalated`/`queued`

### New: `TicketDeflection/Endpoints/AutonomyEndpoints.cs`

Three minimal Minimal API endpoints:

````
GET /api/autonomy/decisions  → { events: LedgerEvent[] }        (newest-first)
GET /api/autonomy/queue      → { blocked, queuedForHuman, recentAutonomous }
GET /api/autonomy/metrics    → { totalEvents, autonomousActed, blocked, queuedForHuman, escalated, lastUpdated }
```

### Modified: `TicketDeflection/Program.cs`

- `AddSingleton(AutonomyLedgerService)()` registration
- `app.MapAutonomyEndpoints()` wiring

### New: `TicketDeflection.Tests/AutonomyEndpointTests.cs`

11 tests total across two classes:

**`AutonomyEndpointTests`** (integration via `WebApplicationFactory`):
- `Decisions_ReturnsOk_WhenNoLedger`
- `Decisions_ReturnsEventsNewestFirst`
- `Queue_ReturnsSeparateBuckets`
- `Metrics_ReturnsAggregatedCounts`
- `Metrics_ReturnsEmpty_WhenNoLedger`

**`AutonomyLedgerServiceTests`** (unit):
- `GetAllEvents_ReturnsEmpty_WhenNoDirExists`
- `GetAllEvents_ParsesArrayFile`
- `GetAllEvents_ParsesSingleObjectFile`
- `GetAllEvents_SkipsMalformedFiles`
- `GetQueue_GroupsCorrectly`
- `GetMetrics_AggregatesCorrectly`

## Test Results

```
Passed! - Failed: 0, Passed: 93, Skipped: 0, Total: 93
````

All 93 tests pass (82 pre-existing + 11 new).

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22597004332)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22597004332, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22597004332 -->

<!-- gh-aw-workflow-id: repo-assist -->