### PR TITLE
[Pipeline] Implement Compliance Scan Engine Service

### DIFF
--- a/TicketDeflection/Program.cs
+++ b/TicketDeflection/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddScoped<PipelineService>();
 builder.Services.AddSingleton<IDecisionLedgerService, DecisionLedgerService>();
 builder.Services.AddSingleton<IShowcaseService, ShowcaseService>();
 builder.Services.AddSingleton<IComplianceRuleLibrary, ComplianceRuleLibrary>();
+builder.Services.AddScoped<IComplianceScanService, ComplianceScanService>();
 builder.Services.AddHttpClient<IGitHubPipelineSnapshotService, GitHubPipelineSnapshotService>();
 builder.Services.AddRazorPages();
 

--- a/TicketDeflection/Services/ComplianceScanService.cs
+++ b/TicketDeflection/Services/ComplianceScanService.cs
@@ -1,0 +1,103 @@
+#nullable enable
+
+using System.Text.RegularExpressions;
+using TicketDeflection.Data;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Services;
+
+public class ComplianceScanService : IComplianceScanService
+{
+    private readonly IComplianceRuleLibrary _ruleLibrary;
+
+    public ComplianceScanService(IComplianceRuleLibrary ruleLibrary)
+    {
+        _ruleLibrary = ruleLibrary;
+    }
+
+    public async Task<ComplianceScan> ScanAsync(string content, ContentType contentType, string? sourceLabel, TicketDbContext db)
+    {
+        bool isTestContext = content.Contains("// test-context", StringComparison.OrdinalIgnoreCase)
+                           || content.Contains("// demo-context", StringComparison.OrdinalIgnoreCase);
+
+        var lines = content.Split('\n');
+        var rules = _ruleLibrary.GetRules();
+        var findings = new List<ComplianceFinding>();
+
+        foreach (var rule in rules)
+        {
+            var matches = rule.Pattern.Matches(content);
+            foreach (Match match in matches)
+            {
+                // Determine actual disposition (cap at ADVISORY for test/demo contexts)
+                var disposition = rule.Disposition;
+                if (isTestContext && disposition == ComplianceDisposition.AUTO_BLOCK)
+                    disposition = ComplianceDisposition.ADVISORY;
+
+                // Compute 1-based line number
+                int lineNumber = 1;
+                int charCount = 0;
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    charCount += lines[i].Length + 1; // +1 for '\n'
+                    if (charCount > match.Index)
+                    {
+                        lineNumber = i + 1;
+                        break;
+                    }
+                }
+
+                // Build redacted excerpt
+                string rawExcerpt = match.Value;
+                string redactedExcerpt = rule.Pattern.Replace(rawExcerpt, "[REDACTED]");
+
+                findings.Add(new ComplianceFinding
+                {
+                    ScanId = Guid.Empty, // will be set below
+                    Regulation = rule.Regulation,
+                    RuleId = rule.RuleId,
+                    RuleName = rule.RuleName,
+                    Citation = rule.Citation,
+                    Category = rule.Category,
+                    Severity = rule.Severity,
+                    Disposition = disposition,
+                    RedactedExcerpt = redactedExcerpt,
+                    LineNumber = lineNumber,
+                    // StopReason only for HUMAN_REQUIRED
+                    StopReason = disposition == ComplianceDisposition.HUMAN_REQUIRED ? rule.StopReason : null,
+                });
+
+                // Only take first match per rule to avoid flooding
+                break;
+            }
+        }
+
+        // Aggregate disposition
+        ComplianceDisposition scanDisposition;
+        if (findings.Any(f => f.Disposition == ComplianceDisposition.AUTO_BLOCK))
+            scanDisposition = ComplianceDisposition.AUTO_BLOCK;
+        else if (findings.Any(f => f.Disposition == ComplianceDisposition.HUMAN_REQUIRED))
+            scanDisposition = ComplianceDisposition.HUMAN_REQUIRED;
+        else
+            scanDisposition = ComplianceDisposition.ADVISORY;
+
+        var scan = new ComplianceScan
+        {
+            ContentType = contentType,
+            SourceLabel = sourceLabel,
+            Disposition = scanDisposition,
+            IsDemo = isTestContext,
+        };
+
+        // Fix up ScanId references
+        foreach (var finding in findings)
+            finding.ScanId = scan.Id;
+
+        scan.Findings = findings;
+
+        db.ComplianceScans.Add(scan);
+        await db.SaveChangesAsync();
+
+        return scan;
+    }
+}

--- a/TicketDeflection/Services/IComplianceScanService.cs
+++ b/TicketDeflection/Services/IComplianceScanService.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+using TicketDeflection.Data;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Services;
+
+public interface IComplianceScanService
+{
+    Task<ComplianceScan> ScanAsync(string content, ContentType contentType, string? sourceLabel, TicketDbContext db);
+}


### PR DESCRIPTION
Closes #343

## Summary

Adds `IComplianceScanService` and `ComplianceScanService` — the core engine that applies the static rule library to submitted content, computes aggregate dispositions, redacts PII from excerpts, and persists scan + findings via `TicketDbContext`.

## Changes

### New Files
- **`TicketDeflection/Services/IComplianceScanService.cs`**: Interface exposing `Task(ComplianceScan) ScanAsync(string content, ContentType contentType, string? sourceLabel, TicketDbContext db)`
- **`TicketDeflection/Services/ComplianceScanService.cs`**: Implementation with:
  - Applies all rules from `IComplianceRuleLibrary.GetRules()` via compiled regex matches
  - Aggregate disposition: any `AUTO_BLOCK` finding → `AUTO_BLOCK`; else any `HUMAN_REQUIRED` → `HUMAN_REQUIRED`; else `ADVISORY`
  - `StopReason` populated only for `HUMAN_REQUIRED` findings; `null` for `AUTO_BLOCK` and `ADVISORY`
  - `RedactedExcerpt` replaces matched content with `[REDACTED]` before persisting
  - Clean content (no rule matches) → `ADVISORY` scan with zero findings
  - Content containing `// test-context` or `// demo-context` caps disposition at `ADVISORY` (no `AUTO_BLOCK`)
  - 1-based line numbers computed from content by splitting on `\n`
  - Scan and findings saved to `TicketDbContext` before returning

### Modified
- **`TicketDeflection/Program.cs`**: Registers `IComplianceScanService` as scoped: `builder.Services.AddScoped(IComplianceScanService, ComplianceScanService)()`

No new NuGet packages added.

## Test Results

```
Build succeeded. 0 warnings, 0 errors.
Total tests: 102  Passed: 102
```

All pre-existing tests continue to pass.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22603118538)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22603118538, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22603118538 -->

<!-- gh-aw-workflow-id: repo-assist -->