### PR TITLE
[Pipeline] Add Compliance Link to Navigation and Landing Page Specimen Section

### DIFF
--- a/TicketDeflection/Pages/Index.cshtml
+++ b/TicketDeflection/Pages/Index.cshtml
@@ -351,6 +351,20 @@
         </div>
     </section>
 
+    <!-- Compliance Scan Service specimen section -->
+    <section class="mb-16" aria-labelledby="compliance-specimen-heading">
+        <div class="text-xs font-bold mb-1 uppercase tracking-widest" style="color: var(--accent)">// COMPLIANCE SCAN SERVICE - SPECIMEN OUTPUT</div>
+        <div class="panel p-6 mt-4">
+            <h2 id="compliance-specimen-heading" class="font-sans text-base font-bold text-white mb-3">Compliance Scan Service</h2>
+            <pre class="text-xs text-dim mb-4 leading-relaxed" style="white-space: pre-wrap; font-family: var(--font-mono);">Scans code, diffs, and logs for PIPEDA and FINTRAC violations.
+AUTO_BLOCK for clear violations. HUMAN_REQUIRED for anything
+that needs legal sign-off. The AI classifies and stops.
+A human decides.</pre>
+            <p class="text-xs text-dim mb-6 leading-relaxed max-w-2xl">The pipeline now ships systems that know their own regulatory limits. The compliance service cannot determine remediation - it flags, classifies, and stops. That boundary is structural, not advisory.</p>
+            <a href="/compliance" class="exec-btn-hero inline-block" style="text-decoration: none;">[ Open Compliance Dashboard -&gt; ]</a>
+        </div>
+    </section>
+
     <!-- Visual boundary: pipeline story ends, specimen begins -->
     <div class="mb-16" style="border-top: 2px solid var(--border); padding-top: 3rem; position: relative;">
         <div class="text-xs font-bold mb-1 uppercase tracking-widest" style="color: var(--accent)">// specimen — the proof, not the point</div>

--- a/TicketDeflection/Pages/Shared/_Layout.cshtml
+++ b/TicketDeflection/Pages/Shared/_Layout.cshtml
@@ -29,6 +29,7 @@
                 <a href="/activity" class="nav-link @(path == "/activity" ? "active" : "")">activity</a>
                 <a href="/operator" class="nav-link @(path == "/operator" ? "active" : "")">operator</a>
                 <a href="/pipeline" class="nav-link @(path == "/pipeline" ? "active" : "")">pipeline</a>
+                <a href="/compliance" class="nav-link @(path == "/compliance" ? "active" : "")">compliance</a>
             </div>
             <div class="flex items-center gap-4">
                 <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="text-dim hover:text-accent transition-colors" aria-label="View source on GitHub">GitHub</a>


### PR DESCRIPTION
Closes #346

## Summary

Adds the compliance service to the site navigation and landing page, connecting the new Compliance Dashboard to the rest of the application.

## Changes

### `TicketDeflection/Pages/Shared/_Layout.cshtml`
- Added `compliance` nav link after the existing `pipeline` link with active-state class matching the existing nav pattern

### `TicketDeflection/Pages/Index.cshtml`
- Added Compliance Scan Service specimen section **above** the existing specimen boundary
- Section includes:
  - Monospace specimen description (PIPEDA/FINTRAC, AUTO_BLOCK, HUMAN_REQUIRED framing)
  - Framing line about structural limits vs advisory
  - `[ Open Compliance Dashboard -> ]` CTA linking to `/compliance`

## Test Results

```
Build succeeded. 0 warnings, 0 errors.
Total tests: 102  Passed: 102
```

All pre-existing tests continue to pass.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22604114912)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22604114912, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22604114912 -->

<!-- gh-aw-workflow-id: repo-assist -->