### PR TITLE
[Pipeline] Add Tests for Compliance Scan Service, Endpoints, and Dashboard

### DIFF
--- a/TicketDeflection.Tests/ComplianceEndpointTests.cs
+++ b/TicketDeflection.Tests/ComplianceEndpointTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using TicketDeflection.Data;
+using TicketDeflection.Models;
+
+namespace TicketDeflection.Tests;
+
+public class ComplianceEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ComplianceEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = $"ComplianceEndpointTestDb_{Guid.NewGuid()}";
+        _factory = factory.WithWebHostBuilder(b =>
+            b.ConfigureServices(services =>
+            {
+                var existing = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<TicketDbContext>));
+                if (existing != null) services.Remove(existing);
+                services.AddDbContext<TicketDbContext>(o =>
+                    o.UseInMemoryDatabase(dbName));
+            }));
+    }
+
+    [Fact]
+    public async Task PostScans_Returns201_With_Findings()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/scans", new
+        {
+            content = "SIN: 123-456-789 in exported log",
+            contentType = 3, // ContentType.FREETEXT
+            sourceLabel = "test"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.True(doc.RootElement.TryGetProperty("findings", out var findings));
+        Assert.True(findings.GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public async Task GetScans_Returns200_List()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/scans");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task GetComplianceMetrics_Returns200_With_NumericFields()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/compliance/metrics");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("totalScans", out var totalScans));
+        Assert.True(root.TryGetProperty("autoBlocked", out _));
+        Assert.True(root.TryGetProperty("humanRequired", out _));
+        Assert.True(root.TryGetProperty("advisory", out _));
+        Assert.True(root.TryGetProperty("pendingDecisions", out _));
+        Assert.Equal(JsonValueKind.Number, totalScans.ValueKind);
+    }
+
+    [Fact]
+    public async Task PostDecision_Returns400_For_AutoBlock_Scan()
+    {
+        var client = _factory.CreateClient();
+
+        // First create an AUTO_BLOCK scan
+        var createResponse = await client.PostAsJsonAsync("/api/scans", new
+        {
+            content = "SIN: 999-888-777",
+            contentType = 3, // ContentType.FREETEXT
+            sourceLabel = "test"
+        });
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var created = await createResponse.Content.ReadAsStringAsync();
+        using var createdDoc = JsonDocument.Parse(created);
+        var scanId = createdDoc.RootElement.GetProperty("id").GetString();
+
+        // Attempt to record a decision on the AUTO_BLOCK scan
+        var decisionResponse = await client.PostAsJsonAsync($"/api/scans/{scanId}/decision", new
+        {
+            operatorId = "test-operator",
+            decision = "approve",
+            notes = "test"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, decisionResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostScansSimulate_Count5_Returns200_With_AggregateCounts()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsync("/api/scans/simulate?count=5", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("count", out _));
+        Assert.True(root.TryGetProperty("autoBlocked", out _));
+        Assert.True(root.TryGetProperty("humanRequired", out _));
+        Assert.True(root.TryGetProperty("advisory", out _));
+    }
+}

--- a/TicketDeflection.Tests/CompliancePageTests.cs
+++ b/TicketDeflection.Tests/CompliancePageTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
+
+namespace TicketDeflection.Tests;
+
+public class CompliancePageTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public CompliancePageTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task CompliancePage_Returns200()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/compliance");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/TicketDeflection.Tests/ComplianceScanServiceTests.cs
+++ b/TicketDeflection.Tests/ComplianceScanServiceTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.EntityFrameworkCore;
+using TicketDeflection.Data;
+using TicketDeflection.Models;
+using TicketDeflection.Services;
+
+namespace TicketDeflection.Tests;
+
+public class ComplianceScanServiceTests
+{
+    private static TicketDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<TicketDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static ComplianceScanService CreateService() =>
+        new(new ComplianceRuleLibrary());
+
+    [Fact]
+    public async Task SIN_Plaintext_Produces_AutoBlock()
+    {
+        using var db = CreateContext();
+        var svc = CreateService();
+
+        var scan = await svc.ScanAsync("SIN: 123-456-789", ContentType.FREETEXT, null, db);
+
+        Assert.Equal(ComplianceDisposition.AUTO_BLOCK, scan.Disposition);
+        Assert.Contains(scan.Findings, f => f.Disposition == ComplianceDisposition.AUTO_BLOCK);
+    }
+
+    [Fact]
+    public async Task FINTRAC_LargeTransaction_Without_ReportingMarker_Produces_Finding()
+    {
+        using var db = CreateContext();
+        var svc = CreateService();
+
+        var scan = await svc.ScanAsync("amount > 10000 in transaction record", ContentType.FREETEXT, null, db);
+
+        Assert.Contains(scan.Findings, f => f.Regulation == ComplianceRegulation.FINTRAC);
+    }
+
+    [Fact]
+    public async Task Clean_Content_Produces_Advisory_With_Zero_Findings()
+    {
+        using var db = CreateContext();
+        var svc = CreateService();
+
+        var scan = await svc.ScanAsync("GET /api/health HTTP/1.1 200 OK — no sensitive data", ContentType.FREETEXT, null, db);
+
+        Assert.Equal(ComplianceDisposition.ADVISORY, scan.Disposition);
+        Assert.Empty(scan.Findings);
+    }
+
+    [Fact]
+    public async Task TestContext_Marker_Does_Not_Produce_AutoBlock()
+    {
+        using var db = CreateContext();
+        var svc = CreateService();
+
+        var scan = await svc.ScanAsync("// test-context\nSIN: 123-456-789", ContentType.FREETEXT, null, db);
+
+        Assert.NotEqual(ComplianceDisposition.AUTO_BLOCK, scan.Disposition);
+        Assert.DoesNotContain(scan.Findings, f => f.Disposition == ComplianceDisposition.AUTO_BLOCK);
+    }
+
+    [Fact]
+    public async Task HumanRequired_Findings_Have_NonNull_StopReason()
+    {
+        using var db = CreateContext();
+        var svc = CreateService();
+
+        // DOB exposed — PIPEDA-003 is HUMAN_REQUIRED
+        var scan = await svc.ScanAsync("dob: 1990-01-15 in user record", ContentType.FREETEXT, null, db);
+
+        var humanFindings = scan.Findings.Where(f => f.Disposition == ComplianceDisposition.HUMAN_REQUIRED).ToList();
+        Assert.NotEmpty(humanFindings);
+        Assert.All(humanFindings, f => Assert.NotNull(f.StopReason));
+    }
+
+    [Fact]
+    public async Task AutoBlock_Findings_Have_Null_StopReason()
+    {
+        using var db = CreateContext();
+        var svc = CreateService();
+
+        var scan = await svc.ScanAsync("SIN: 456-789-123", ContentType.FREETEXT, null, db);
+
+        var autoBlockFindings = scan.Findings.Where(f => f.Disposition == ComplianceDisposition.AUTO_BLOCK).ToList();
+        Assert.NotEmpty(autoBlockFindings);
+        Assert.All(autoBlockFindings, f => Assert.Null(f.StopReason));
+    }
+
+    [Fact]
+    public async Task Any_AutoBlock_Finding_Sets_Scan_Disposition_To_AutoBlock()
+    {
+        using var db = CreateContext();
+        var svc = CreateService();
+
+        // Contains both AUTO_BLOCK (SIN) and HUMAN_REQUIRED (DOB) content
+        var scan = await svc.ScanAsync("SIN: 123-456-789 and dob: 1985-06-20", ContentType.FREETEXT, null, db);
+
+        Assert.Equal(ComplianceDisposition.AUTO_BLOCK, scan.Disposition);
+    }
+
+    [Fact]
+    public async Task Only_HumanRequired_Findings_Sets_Scan_Disposition_To_HumanRequired()
+    {
+        using var db = CreateContext();
+        var svc = CreateService();
+
+        // DOB triggers HUMAN_REQUIRED but not AUTO_BLOCK
+        var scan = await svc.ScanAsync("dob: 1990-01-15 in exported user report", ContentType.FREETEXT, null, db);
+
+        Assert.Equal(ComplianceDisposition.HUMAN_REQUIRED, scan.Disposition);
+    }
+}

--- a/TicketDeflection/Models/ComplianceDecision.cs
+++ b/TicketDeflection/Models/ComplianceDecision.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Text.Json.Serialization;
+
 namespace TicketDeflection.Models;
 
 public class ComplianceDecision
@@ -10,5 +12,6 @@ public class ComplianceDecision
     public string Decision { get; set; } = string.Empty;
     public string? Notes { get; set; }
     public DateTimeOffset DecidedAt { get; set; } = DateTimeOffset.UtcNow;
+    [JsonIgnore]
     public ComplianceScan? Scan { get; set; }
 }

--- a/TicketDeflection/Models/ComplianceFinding.cs
+++ b/TicketDeflection/Models/ComplianceFinding.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Text.Json.Serialization;
+
 namespace TicketDeflection.Models;
 
 public class ComplianceFinding
@@ -17,5 +19,7 @@ public class ComplianceFinding
     public int? LineNumber { get; set; }
     /// <summary>Populated only for HUMAN_REQUIRED findings; null for AUTO_BLOCK and ADVISORY.</summary>
     public string? StopReason { get; set; }
+    [JsonIgnore]
     public ComplianceScan? Scan { get; set; }
 }
+


### PR DESCRIPTION
Closes #347

## Summary

Adds three test files covering the Compliance Scan Service, API endpoints, and dashboard page, as specified in the acceptance criteria.

## New Test Files

### `TicketDeflection.Tests/ComplianceScanServiceTests.cs` (8 tests)
Unit tests for the compliance scan engine logic:
- PIPEDA SIN plaintext match → `AUTO_BLOCK` disposition
- FINTRAC large transaction without reporting marker → produces finding
- Clean content → `ADVISORY` with zero findings
- `// test-context` marker → no `AUTO_BLOCK` produced
- `HUMAN_REQUIRED` findings have non-null `StopReason`
- `AUTO_BLOCK` findings have null `StopReason`
- Any `AUTO_BLOCK` finding → scan disposition is `AUTO_BLOCK`
- Only `HUMAN_REQUIRED` findings → scan disposition is `HUMAN_REQUIRED`

### `TicketDeflection.Tests/ComplianceEndpointTests.cs` (5 tests)
Integration tests using `WebApplicationFactory(Program)` with isolated in-memory DB:
- `POST /api/scans` → HTTP 201 with findings
- `GET /api/scans` → HTTP 200 list
- `GET /api/compliance/metrics` → HTTP 200 with numeric fields
- `POST /api/scans/{id}/decision` → HTTP 400 for AUTO_BLOCK scans
- `POST /api/scans/simulate?count=5` → HTTP 200 with aggregate counts

### `TicketDeflection.Tests/CompliancePageTests.cs` (1 test)
- `GET /compliance` → HTTP 200

## Bug Fix (incidental, required for tests to pass)

Added `[JsonIgnore]` to the `Scan` navigation back-reference on `ComplianceFinding` and `ComplianceDecision`. Without this, EF Core's identity resolution creates a circular reference (`ComplianceScan → Findings → Finding.Scan → ComplianceScan...`) that causes HTTP 500 on `GET /api/scans`.

## Test Results

```
Build succeeded. 0 warnings, 0 errors.
Total tests: 116  Passed: 116
```

All 14 new tests pass. All 102 pre-existing tests continue to pass.

---
*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22604114912)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22604114912, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22604114912 -->

<!-- gh-aw-workflow-id: repo-assist -->