### PR TITLE
[Pipeline] Fix missing nav links causing CI test failure

### DIFF
--- a/TicketDeflection/Pages/Shared/_Layout.cshtml
+++ b/TicketDeflection/Pages/Shared/_Layout.cshtml
@@ -21,6 +21,9 @@
         var navItems = new (string Href, string Label)[]
         {
             ("/", "overview"),
+            ("/dashboard", "dashboard"),
+            ("/tickets", "tickets"),
+            ("/activity", "activity"),
             ("/operator", "operator"),
             ("/pipeline", "pipeline"),
             ("/compliance", "compliance")


### PR DESCRIPTION
Closes #356

## Summary

The `NavigationLayoutTests.SharedNavigation_RendersDedicatedLinkRowWithDistinctTargets` test was failing because the shared `_Layout.cshtml` navigation array was missing three entries: `/dashboard`, `/tickets`, and `/activity`.

## PRD Fidelity

The PRD for Run 07 (Compliance Scan Service) specifies the compliance link be added to the shared navigation. Previous runs added `/dashboard`, `/tickets`, and `/activity` pages but did not add them to the navigation. This fix restores the full set of nav links that the tests expect.

## Changes

- **`TicketDeflection/Pages/Shared/_Layout.cshtml`**: Added `/dashboard` (dashboard), `/tickets` (tickets), and `/activity` (activity) to the `navItems` array.

## Test Results

All 124 tests pass:
```
Test Run Successful.
Total tests: 124
     Passed: 124
 Total time: 10.0162 Seconds
```

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22609053342)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22609053342, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22609053342 -->

<!-- gh-aw-workflow-id: repo-assist -->