### PR TITLE
[Pipeline] Update NavigationLayoutTests to match current 4-page navigation

### DIFF
--- a/TicketDeflection.Tests/NavigationLayoutTests.cs
+++ b/TicketDeflection.Tests/NavigationLayoutTests.cs
@@ -16,14 +16,11 @@ public class NavigationLayoutTests : IClassFixture<WebApplicationFactory<Program
     {
         var client = _factory.CreateClient();
 
-        var html = await client.GetStringAsync("/dashboard");
+        var html = await client.GetStringAsync("/");
 
         Assert.Contains("status-bar-brand-row", html);
         Assert.Contains("status-bar-links", html);
         Assert.Contains("href=\"/\"", html);
-        Assert.Contains("href=\"/dashboard\"", html);
-        Assert.Contains("href=\"/tickets\"", html);
-        Assert.Contains("href=\"/activity\"", html);
         Assert.Contains("href=\"/operator\"", html);
         Assert.Contains("href=\"/pipeline\"", html);
         Assert.Contains("href=\"/compliance\"", html);


### PR DESCRIPTION
Closes #359

## Summary

Updates `NavigationLayoutTests.SharedNavigation_RendersDedicatedLinkRowWithDistinctTargets` to assert only the 4 current navigation links:
- `href="/"` (Overview)
- `href="/operator"` (Operator Console)
- `href="/pipeline"` (Pipeline Monitor)
- `href="/compliance"` (Compliance Scanner)

Removes stale assertions for `/dashboard`, `/tickets`, and `/activity` that were removed in the intentional navigation trim (commit `21781c2`). Also changes the test page load from `/dashboard` to `/` for a stable primary route.

**No changes to `_Layout.cshtml` or any production code.**

## PRD Fidelity

This is a test-only bug fix per issue #359. No PRD traceability applies.

## Test Results

```
Test Run Successful.
Total tests: 124
     Passed: 124
 Total time: 7.16 Seconds
```

---

_This PR was created by Pipeline Assistant._




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22609299393)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22609299393, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22609299393 -->

<!-- gh-aw-workflow-id: repo-assist -->