### PR TITLE
[Pipeline] Trim shared navigation to 4 pages: overview, operator, pipeline, compliance

### DIFF
--- a/TicketDeflection/Pages/Shared/_Layout.cshtml
+++ b/TicketDeflection/Pages/Shared/_Layout.cshtml
@@ -21,9 +21,6 @@
         var navItems = new (string Href, string Label)[]
         {
             ("/", "overview"),
-            ("/dashboard", "dashboard"),
-            ("/tickets", "tickets"),
-            ("/activity", "activity"),
             ("/operator", "operator"),
             ("/pipeline", "pipeline"),
             ("/compliance", "compliance")


### PR DESCRIPTION
Closes #362

## Summary

Removes `/dashboard`, `/tickets`, and `/activity` from the shared nav bar array in `_Layout.cshtml`. The pages themselves are untouched and remain accessible via direct URL — only the nav links are hidden.

### PRD Fidelity

This is a standalone cleanup issue (no PRD traceability section). The change is exactly scoped to the issue: 3 nav items removed from the `navItems` array, nothing else changed.

### Changes

- `TicketDeflection/Pages/Shared/_Layout.cshtml` — removed `dashboard`, `tickets`, `activity` entries from `navItems`

### Test Results

```
Total tests: 124
     Passed: 124
```

`NavigationLayoutTests` passes — the test asserts the 4 retained links are present, which they are.

---

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22609885088)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22609885088, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22609885088 -->

<!-- gh-aw-workflow-id: repo-assist -->