### PR TITLE
[Pipeline] Create /experiment route with curated Unsplash gallery

### DIFF
--- a/TicketDeflection.Tests/ExperimentPageTests.cs
+++ b/TicketDeflection.Tests/ExperimentPageTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace TicketDeflection.Tests;
+
+public class ExperimentPageTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ExperimentPageTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithTestAuth();
+    }
+
+    [Fact]
+    public async Task ExperimentPage_Returns200()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/experiment");
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ExperimentPage_ContainsGalleryGrid()
+    {
+        var client = _factory.CreateClient();
+        var html = await client.GetStringAsync("/experiment");
+        Assert.Contains("gallery-grid", html);
+        Assert.Contains("gallery-item", html);
+    }
+
+    [Fact]
+    public async Task ExperimentPage_ContainsUnsplashImages()
+    {
+        var client = _factory.CreateClient();
+        var html = await client.GetStringAsync("/experiment");
+        Assert.Contains("images.unsplash.com", html);
+        Assert.Contains("unsplash.com/photos/", html);
+    }
+
+    [Fact]
+    public async Task ExperimentPage_RendersAllTwelvePhotos()
+    {
+        var client = _factory.CreateClient();
+        var html = await client.GetStringAsync("/experiment");
+        Assert.Contains("12 frames", html);
+        // Verify first and last photo IDs are present
+        Assert.Contains("1518770660439-4636190af475", html);
+        Assert.Contains("1534972195531-d236914a371a", html);
+    }
+
+    [Fact]
+    public async Task ExperimentPage_IsLinkedFromNavigation()
+    {
+        var client = _factory.CreateClient();
+        var html = await client.GetStringAsync("/");
+        Assert.Contains("href=\"/experiment\"", html);
+    }
+}

--- a/TicketDeflection/Pages/Experiment.cshtml
+++ b/TicketDeflection/Pages/Experiment.cshtml
@@ -1,0 +1,179 @@
+@page "/experiment"
+@model ExperimentModel
+@{
+    ViewData["Title"] = "Experiment — prd-to-prod";
+    ViewData["NavTitle"] = "EXPERIMENT";
+}
+
+@section Styles {
+<style>
+    .exp-hero {
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 2rem;
+        margin-bottom: 2.5rem;
+    }
+    .exp-label {
+        font-size: 0.7rem;
+        color: var(--dim);
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        margin-bottom: 0.6rem;
+    }
+    .exp-title {
+        font-family: var(--sans);
+        font-size: 2.5rem;
+        font-weight: 700;
+        color: #e8edf5;
+        line-height: 1.1;
+        margin-bottom: 0.8rem;
+    }
+    .exp-subtitle {
+        font-size: 0.9rem;
+        color: var(--dim);
+        max-width: 600px;
+        line-height: 1.7;
+    }
+    .exp-subtitle strong { color: var(--accent); font-weight: 500; }
+
+    /* Masonry-style photo grid using CSS columns */
+    .gallery-grid {
+        columns: 3;
+        column-gap: 12px;
+        line-height: 0;
+    }
+    @@media (max-width: 900px) {
+        .gallery-grid { columns: 2; }
+    }
+    @@media (max-width: 560px) {
+        .gallery-grid { columns: 1; }
+        .exp-title { font-size: 1.8rem; }
+    }
+
+    .gallery-item {
+        display: inline-block;
+        width: 100%;
+        margin-bottom: 12px;
+        position: relative;
+        overflow: hidden;
+        border: 1px solid var(--border);
+        line-height: 0;
+    }
+    .gallery-item img {
+        width: 100%;
+        height: auto;
+        display: block;
+        filter: brightness(0.72) saturate(0.8);
+        transition: filter 0.35s ease, transform 0.35s ease;
+    }
+    .gallery-item:hover img {
+        filter: brightness(0.9) saturate(1.15);
+        transform: scale(1.025);
+    }
+    .gallery-item::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border: 2px solid transparent;
+        transition: border-color 0.3s ease;
+        pointer-events: none;
+    }
+    .gallery-item:hover::after {
+        border-color: var(--accent);
+        box-shadow: 0 0 24px rgba(0, 170, 255, 0.18) inset;
+    }
+    .gallery-caption {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        padding: 28px 14px 12px;
+        background: linear-gradient(to top, rgba(4, 8, 16, 0.88) 0%, transparent 100%);
+        color: var(--text);
+        font-size: 0.65rem;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        line-height: 1;
+        transform: translateY(4px);
+        opacity: 0.75;
+        transition: opacity 0.3s, transform 0.3s;
+    }
+    .gallery-item:hover .gallery-caption {
+        opacity: 1;
+        transform: translateY(0);
+        color: var(--accent);
+    }
+    .gallery-index {
+        color: rgba(0, 170, 255, 0.4);
+        margin-right: 6px;
+    }
+
+    .gallery-footer {
+        margin-top: 2rem;
+        padding-top: 1.2rem;
+        border-top: 1px solid var(--border);
+        font-size: 0.7rem;
+        color: var(--dim);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .gallery-footer a { color: var(--accent); text-decoration: none; }
+    .gallery-footer a:hover { text-decoration: underline; }
+
+    .tag-exp {
+        display: inline-block;
+        font-size: 0.65rem;
+        padding: 2px 8px;
+        border: 1px solid var(--border);
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        margin-right: 6px;
+    }
+</style>
+}
+
+<div class="max-w-5xl mx-auto px-4 py-10">
+
+    <div class="exp-hero">
+        <div class="exp-label">// visual experiment — prd-to-prod pipeline</div>
+        <h1 class="exp-title">Curated Gallery</h1>
+        <p class="exp-subtitle">
+            Twelve frames hand-picked to echo this repo's aesthetic —
+            <strong>dark terminals</strong>, <strong>neural meshes</strong>, <strong>city voids</strong> —
+            all sourced from <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer" style="color:var(--accent);">Unsplash</a>
+            and rendered through the same design tokens that power the pipeline dashboard.
+        </p>
+    </div>
+
+    <div class="gallery-grid" role="list" aria-label="Curated photo gallery">
+        @for (int i = 0; i < Model.Photos.Count; i++)
+        {
+            var photo = Model.Photos[i];
+            <div class="gallery-item" role="listitem">
+                <a href="https://unsplash.com/photos/@photo.Id"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   aria-label="@photo.Alt — view on Unsplash">
+                    <img src="@photo.UrlSmall()"
+                         alt="@photo.Alt"
+                         loading="lazy"
+                         width="600"
+                         height="450" />
+                    <div class="gallery-caption">
+                        <span class="gallery-index">@((i + 1).ToString("D2"))</span>@photo.Label
+                    </div>
+                </a>
+            </div>
+        }
+    </div>
+
+    <div class="gallery-footer">
+        <span class="tag-exp">@Model.Photos.Count frames</span>
+        Photos by various photographers on
+        <a href="https://unsplash.com" target="_blank" rel="noopener noreferrer">Unsplash</a>.
+        Free to use under the
+        <a href="https://unsplash.com/license" target="_blank" rel="noopener noreferrer">Unsplash License</a>.
+    </div>
+
+</div>

--- a/TicketDeflection/Pages/Experiment.cshtml.cs
+++ b/TicketDeflection/Pages/Experiment.cshtml.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TicketDeflection.Pages;
+
+public class ExperimentModel : PageModel
+{
+    public IReadOnlyList<GalleryPhoto> Photos { get; private set; } = [];
+
+    public void OnGet()
+    {
+        Photos = GalleryPhoto.Curated;
+    }
+}
+
+public sealed record GalleryPhoto(string Id, string Label, string Alt, int Width, int Height)
+{
+    // Well-known Unsplash photo IDs curated for a dark tech / AI aesthetic
+    public static readonly IReadOnlyList<GalleryPhoto> Curated =
+    [
+        new("1518770660439-4636190af475", "code stream",           "Glowing code on a dark monitor",            800, 533),
+        new("1555066931-bf19f8fd1085",   "terminal depth",         "Dark terminal with neon syntax highlight",  800, 533),
+        new("1526374965328-7f61d4dc18c5","matrix rain",            "Green code characters falling on dark bg",  800, 533),
+        new("1558494949-ef010cbdcc31",   "data glitch",            "Abstract glitch art in deep blues",         800, 534),
+        new("1451187580459-43490279c0fa","orbital view",           "Earth from orbit against the void",         800, 533),
+        new("1550751827-4bd374c3f58b",   "city at night",          "City skyline illuminated in darkness",      800, 534),
+        new("1620641788421-7a1c342ea42e","neural mesh",            "Abstract neural-network node mesh",         800, 533),
+        new("1635070041078-e363dbe005cb","deep signal",            "Colourful abstract AI signal visualised",   800, 533),
+        new("1539701938214-0d9736e1c16b","void current",           "Dark abstract flowing energy in the void",  800, 533),
+        new("1576669801775-4d8e73f5d46e","syntax layer",           "Lines of code scrolling on dark screen",    800, 533),
+        new("1614624532983-4ce71639ab10","circuit macro",          "Close-up of a circuit board, dark macro",   800, 534),
+        new("1534972195531-d236914a371a","infrared city",          "City street at night, infrared palette",    800, 533),
+    ];
+
+    public string Url(int w = 800, int h = 600) =>
+        $"https://images.unsplash.com/photo-{Id}?w={w}&h={h}&auto=format&fit=crop&q=80";
+
+    public string UrlSmall() => Url(600, 450);
+}

--- a/TicketDeflection/Pages/Shared/_Layout.cshtml
+++ b/TicketDeflection/Pages/Shared/_Layout.cshtml
@@ -23,7 +23,8 @@
             ("/", "overview"),
             ("/operator", "operator"),
             ("/pipeline", "pipeline"),
-            ("/compliance", "compliance")
+            ("/compliance", "compliance"),
+            ("/experiment", "experiment")
         };
     }
 


### PR DESCRIPTION
Closes #373

## Summary

Adds a new `/experiment` page — a visually polished image gallery sourced from Unsplash, styled to match the site's dark-terminal aesthetic.

## Changes

| File | Change |
|------|--------|
| `TicketDeflection/Pages/Experiment.cshtml` | New Razor Page — masonry gallery with 12 curated Unsplash photos |
| `TicketDeflection/Pages/Experiment.cshtml.cs` | `ExperimentModel` PageModel + `GalleryPhoto` record type |
| `TicketDeflection/Pages/Shared/_Layout.cshtml` | Added `experiment` as 5th nav item |
| `TicketDeflection.Tests/ExperimentPageTests.cs` | 5 new tests: 200 response, gallery markup, Unsplash URLs, photo count, nav link |

## Gallery Design

- **12 curated Unsplash photos** — dark code terminals, neural meshes, city voids, orbital views
- **CSS masonry layout** (3 columns → 2 → 1) using `columns` property
- **Hover interactions** — brightness lift, scale, accent-blue glow border, caption slide-up
- **Dark aesthetic** — images rendered at reduced brightness/saturation by default to match `--bg: #080c12`
- **Accessibility** — `role="list"` on grid, `aria-label` on each link, `loading="lazy"` on images
- **Unsplash attribution** — footer with license link

## PRD Fidelity

This is a direct user issue (not a PRD decomposer artifact). The issue requested: a new `/experiment` route, images from Unsplash, a nice design that fits the site's vibe. All three requirements are implemented.

## Test Results

```
Total tests: 172
     Passed: 172
```

All existing tests pass. 5 new tests added in `ExperimentPageTests.cs`.

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22696621392) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+is%3Apr+%22gh-aw-workflow-id%3A+repo-assist%22+in%3Abody)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22696621392, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22696621392 -->

<!-- gh-aw-workflow-id: repo-assist -->