### PR TITLE
[Pipeline] Hero heading fix: balance line wrapping on all viewports

### DIFF
--- a/PRDtoProd/Pages/Index.cshtml
+++ b/PRDtoProd/Pages/Index.cshtml
@@ -45,6 +45,7 @@
         line-height: 1.15;
         letter-spacing: -0.02em;
         margin-bottom: 24px;
+        text-wrap: balance;
     }
 
     .hero-sub {
@@ -266,7 +267,7 @@
     <section class="hero-grid" aria-labelledby="hero-heading">
         <div>
             <h1 id="hero-heading" class="hero-headline cursor-blink">
-                PRD to deployed code.<br />AI builds. Humans decide what ships.
+                PRD to deployed code. AI builds. Humans decide what ships.
             </h1>
             <p class="hero-sub">
                 An autonomous delivery pipeline powered by


### PR DESCRIPTION
Closes #383

## Summary
The hero heading was using a hard `<br />` break that caused awkward multi-line wrapping on mid-range viewport widths (e.g. ~600–900px). The second line "AI builds. Humans decide what ships." would break in unexpected places.

## Changes
- **`PRDtoProd/Pages/Index.cshtml`**: Removed `<br />` from the `<h1>` hero headline and added `text-wrap: balance` to `.hero-headline` CSS. This lets the browser distribute words evenly across lines at any viewport width.

## Before / After
| Before | After |
|--------|-------|
| Line 1: "PRD to deployed code." | Browser balances the full text |
| Line 2 (may wrap): "AI builds. Humans decide what ships." | Consistent, natural wrapping |

## Testing
- No test coverage required for a heading style fix
- Existing `LandingPageTests` and `NavigationLayoutTests` are unaffected

---
_This PR was created by Pipeline Assistant._




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22704343975) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+repo-assist%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22704343975, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22704343975 -->

<!-- gh-aw-workflow-id: repo-assist -->