### PR TITLE
[Pipeline] Mobile responsiveness: fix layout issues on Compliance, Operator, and Activity pages

### DIFF
--- a/PRDtoProd/Pages/Activity.cshtml
+++ b/PRDtoProd/Pages/Activity.cshtml
@@ -16,6 +16,12 @@
         align-items: start;
     }
     .log-line:last-child { border-bottom: none; }
+    @@media (max-width: 480px) {
+        .log-line {
+            grid-template-columns: 1fr;
+            gap: 4px;
+        }
+    }
     .log-ts {
         color: var(--dim);
         font-size: 0.7rem;

--- a/PRDtoProd/Pages/Compliance.cshtml
+++ b/PRDtoProd/Pages/Compliance.cshtml
@@ -11,12 +11,14 @@
         background: rgba(4, 10, 20, 0.7);
         border: 1px solid var(--border);
         border-top: 2px solid var(--accent);
+        overflow-x: auto;
     }
     .metric-item {
         display: flex;
         flex-direction: column;
         align-items: center;
         padding: 12px 28px;
+        min-width: 100px;
     }
     .metric-item + .metric-item {
         border-left: 1px solid var(--border);

--- a/PRDtoProd/Pages/Operator.cshtml
+++ b/PRDtoProd/Pages/Operator.cshtml
@@ -17,6 +17,11 @@
         grid-template-columns: 1.2fr 0.8fr;
         gap: 24px;
     }
+    @@media (max-width: 640px) {
+        .boundary-grid {
+            grid-template-columns: 1fr;
+        }
+    }
     .boundary-rule {
         color: var(--red);
         font-family: var(--sans);


### PR DESCRIPTION
Closes #382

## Summary
Ensures the landing page and all user-facing pages are responsive and appropriate for mobile and desktop.

## Changes

### `PRDtoProd/Pages/Compliance.cshtml`
- Added `overflow-x: auto` to `.metrics-bar` so the 5-metric strip scrolls horizontally on narrow screens instead of crushing each cell to an unusable width
- Added `min-width: 100px` to `.metric-item` to keep metrics legible when scrolled

### `PRDtoProd/Pages/Operator.cshtml`
- Added a `@media (max-width: 640px)` breakpoint to `.boundary-grid` so the 2-column boundary detail panel collapses to a single column on phones

### `PRDtoProd/Pages/Activity.cshtml`
- Added a `@media (max-width: 480px)` breakpoint to `.log-line` so the fixed-width 160px timestamp column stacks vertically above the log content on very small screens

## Pages already responsive (no changes needed)
- **Index (/)**: Hero grid has `@media (min-width: 768px)` breakpoint; pipeline schematic flows naturally
- **Pipeline (/pipeline)**: Has `@media (max-width: 900px)` and `@media (max-width: 640px)` breakpoints on stage grid
- **Operator (/operator)**: Metrics grid and main sections use Tailwind `md:` / `lg:` responsive classes

## Notes
> The issue requested Playwright MCP verification. Playwright MCP is not available in the agent CI environment; changes were validated by code inspection against viewport widths documented in the CSS.

---
_This PR was created by Pipeline Assistant._




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22704343975) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+repo-assist%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22704343975, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22704343975 -->

<!-- gh-aw-workflow-id: repo-assist -->