### PR TITLE
[code-simplifier] refactor: use Math.Clamp for count clamping in endpoint handlers

### DIFF
--- a/PRDtoProd/Endpoints/ComplianceEndpoints.cs
+++ b/PRDtoProd/Endpoints/ComplianceEndpoints.cs
@@ -171,13 +171,12 @@ public static class ComplianceEndpoints
         TicketDbContext db,
         int count = 10)
     {
-        if (count < 1) count = 1;
-        if (count > 50) count = 50;
+        count = Math.Clamp(count, 1, 50);
 
         var random = new Random();
         int autoBlocked = 0, humanRequired = 0, advisory = 0;
 
-        for (int i = 0; i < count; i++)
+        for (var i = 0; i < count; i++)
         {
             var content = SampleContents[random.Next(SampleContents.Length)];
             var scan = await scanner.ScanAsync(content, ContentType.FREETEXT, "simulate", db);

--- a/PRDtoProd/Endpoints/SimulateEndpoints.cs
+++ b/PRDtoProd/Endpoints/SimulateEndpoints.cs
@@ -50,8 +50,7 @@ public static class SimulateEndpoints
     private static async Task<IResult> RunSimulation(
         TicketDbContext db, PipelineService pipeline, int count = 10)
     {
-        if (count < 1) count = 1;
-        if (count > 100) count = 100;
+        count = Math.Clamp(count, 1, 100);
 
         // Reset to a clean slate before each demo run
         db.ActivityLogs.RemoveRange(db.ActivityLogs);


### PR DESCRIPTION
This PR simplifies recently modified endpoint code to use idiomatic C# patterns while preserving all functionality.

### Files Simplified

- `PRDtoProd/Endpoints/SimulateEndpoints.cs` — Replace two `if` guards with `Math.Clamp`
- `PRDtoProd/Endpoints/ComplianceEndpoints.cs` — Replace two `if` guards with `Math.Clamp`; normalize loop var to `var`

### Improvements Made

**Reduced verbosity via `Math.Clamp`**

Before:
```csharp
if (count < 1) count = 1;
if (count > 100) count = 100;
```

After:
```csharp
count = Math.Clamp(count, 1, 100);
```

The same pattern was applied in `ComplianceEndpoints` (clamped to 1–50). `Math.Clamp` is the idiomatic .NET BCL method for this operation and makes the intent immediately clear in a single expression.

**Consistent loop variable style**

`ComplianceEndpoints` used `for (int i = ...)` while `SimulateEndpoints` already used `for (var i = ...)`. Normalized to `var` throughout, matching the existing convention and Microsoft C# guidelines (use `var` when the type is obvious from context).

### Changes Based On

Recent changes from:
- [#390](https://github.com/samuelkahessay/prd-to-prod/pull/390) — Refactor: extract shared TicketResponse mapping to TicketDtos.cs
- [#386](https://github.com/samuelkahessay/prd-to-prod/pull/386) — Mobile responsiveness fixes (SimulateEndpoints touched in same set)

### Testing

- ✅ Build succeeds (`dotnet build PRDtoProd.sln -c Release` — 0 errors, 0 warnings)
- ✅ No functional changes — `Math.Clamp(x, min, max)` is mathematically identical to the two-if guard pattern
- ✅ Existing tests (`Simulate_ExceedsMax_CappedAt100`, compliance simulation tests) continue to validate clamping behavior

### Review Focus

Please verify:
- Clamping bounds are unchanged (1–100 for simulate, 1–50 for compliance simulation)
- No unintended side effects from the style normalization

---

*Automated by Code Simplifier Agent — analyzing code from the last 24 hours*

**References:**
- [§22736727912](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22736727912)


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22736727912) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 7 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `crl3.digicert.com`
> - `crl4.digicert.com`
> - `ocsp.digicert.com`
> - `s.symcb.com`
> - `s.symcd.com`
> - `tscrl.ws.symantec.com`
> - `tsocsp.ws.symantec.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "crl3.digicert.com"
>     - "crl4.digicert.com"
>     - "ocsp.digicert.com"
>     - "s.symcb.com"
>     - "s.symcd.com"
>     - "tscrl.ws.symantec.com"
>     - "tsocsp.ws.symantec.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> - [x] expires <!-- gh-aw-expires: 2026-03-06T21:12:19.194Z --> on Mar 6, 2026, 9:12 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 22736727912, workflow_id: code-simplifier, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22736727912 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->