### PR TITLE
[Pipeline] Consolidate tokenization logic into MatchingService

### DIFF
--- a/PRDtoProd.Tests/MatchingServiceTests.cs
+++ b/PRDtoProd.Tests/MatchingServiceTests.cs
@@ -203,4 +203,90 @@ public class MatchingServiceTests
         Assert.Equal(TicketStatus.Escalated, ticket.Status);
         Assert.True(score < 0.3, $"Expected score < 0.3 for escalated ticket, got {score}");
     }
+
+    [Fact]
+    public void GetTopMatches_ReturnsRankedMatches()
+    {
+        using var context = CreateContext();
+        SeedPasswordArticle(context);
+        context.KnowledgeArticles.Add(new KnowledgeArticle
+        {
+            Id = Guid.NewGuid(),
+            Title = "Billing FAQ",
+            Content = "Your invoice can be found in the billing portal.",
+            Tags = "billing,invoice,payment",
+            Category = TicketCategory.Other
+        });
+        context.SaveChanges();
+
+        var ticket = new Ticket
+        {
+            Title = "forgot password",
+            Description = "",
+            Status = TicketStatus.New
+        };
+
+        var service = CreateService();
+        var articles = context.KnowledgeArticles.ToList();
+        var matches = service.GetTopMatches(ticket, articles);
+
+        // At least one match with a non-zero score
+        Assert.NotEmpty(matches);
+        // The password-related article should outscore the billing article
+        Assert.Equal("Password Reset Guide", matches[0].Title);
+        // Results should be ordered descending by score
+        for (int i = 1; i < matches.Count; i++)
+            Assert.True(matches[i - 1].Score >= matches[i].Score);
+    }
+
+    [Fact]
+    public void GetTopMatches_NoMatchingArticle_ReturnsEmpty()
+    {
+        using var context = CreateContext();
+        SeedPasswordArticle(context);
+
+        var ticket = new Ticket
+        {
+            Title = "zxqvbnm asdfgh",
+            Description = "",
+            Status = TicketStatus.New
+        };
+
+        var service = CreateService();
+        var articles = context.KnowledgeArticles.ToList();
+        var matches = service.GetTopMatches(ticket, articles);
+
+        Assert.Empty(matches);
+    }
+
+    [Fact]
+    public void GetTopMatches_RespectsTopN()
+    {
+        using var context = CreateContext();
+        for (int i = 0; i < 5; i++)
+        {
+            context.KnowledgeArticles.Add(new KnowledgeArticle
+            {
+                Id = Guid.NewGuid(),
+                Title = $"Password Article {i}",
+                Content = $"password reset login email account guide {i}",
+                Tags = "password,reset",
+                Category = TicketCategory.AccountIssue
+            });
+        }
+        context.SaveChanges();
+
+        var ticket = new Ticket
+        {
+            Title = "forgot password reset login",
+            Description = "",
+            Status = TicketStatus.New
+        };
+
+        var service = CreateService();
+        var articles = context.KnowledgeArticles.ToList();
+        var matches = service.GetTopMatches(ticket, articles, topN: 2);
+
+        Assert.Equal(2, matches.Count);
+    }
 }

--- a/PRDtoProd/DTOs/ResolveDtos.cs
+++ b/PRDtoProd/DTOs/ResolveDtos.cs
@@ -1,0 +1,4 @@
+namespace PRDtoProd.DTOs;
+
+public record ArticleMatch(Guid ArticleId, string Title, double Score);
+public record ResolveResponse(TicketResponse Ticket, List<ArticleMatch> Matches);

--- a/PRDtoProd/Endpoints/ResolveEndpoints.cs
+++ b/PRDtoProd/Endpoints/ResolveEndpoints.cs
@@ -19,40 +19,16 @@ public static class ResolveEndpoints
         var ticket = await db.Tickets.FindAsync(id);
         if (ticket is null) return TypedResults.NotFound();
 
-        // Load articles for matching
+        // Resolve the ticket (sets Status and Resolution)
         matcher.ResolveTicket(ticket, db);
         await db.SaveChangesAsync();
 
-        // Compute confidence scores for response
+        // Compute confidence scores for response via the service layer
         var articles = db.KnowledgeArticles.ToList();
-        var ticketTokens = Tokenize($"{ticket.Title} {ticket.Description}");
-        var matches = articles
-            .Select(a => new ArticleMatch(
-                a.Id, a.Title,
-                Jaccard(ticketTokens, Tokenize($"{a.Content} {a.Tags}"))))
-            .Where(m => m.Score > 0)
-            .OrderByDescending(m => m.Score)
-            .Take(3)
-            .ToList();
+        var matches = matcher.GetTopMatches(ticket, articles).ToList();
 
         var ticketResponse = ticket.ToResponse();
 
         return TypedResults.Ok(new ResolveResponse(ticketResponse, matches));
     }
-
-    private static HashSet<string> Tokenize(string text) =>
-        text.Split([' ', '\t', ',', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
-            .Select(t => t.ToLowerInvariant())
-            .ToHashSet();
-
-    private static double Jaccard(HashSet<string> a, HashSet<string> b)
-    {
-        if (a.Count == 0 && b.Count == 0) return 0;
-        var intersection = a.Intersect(b).Count();
-        var union = a.Union(b).Count();
-        return intersection / (double)union;
-    }
 }
-
-public record ArticleMatch(Guid ArticleId, string Title, double Score);
-public record ResolveResponse(TicketResponse Ticket, List<ArticleMatch> Matches);

--- a/PRDtoProd/Services/MatchingService.cs
+++ b/PRDtoProd/Services/MatchingService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using PRDtoProd.Data;
+using PRDtoProd.DTOs;
 using PRDtoProd.Models;
 
 namespace PRDtoProd.Services;
@@ -49,6 +50,27 @@ public class MatchingService
         }
 
         return (bestScore, bestArticle);
+    }
+
+    public IReadOnlyList<ArticleMatch> GetTopMatches(Ticket ticket, IEnumerable<KnowledgeArticle> articles, int topN = 3)
+    {
+        var ticketTokens = Tokenize($"{ticket.Title} {ticket.Description}");
+        return articles
+            .Select(a => new ArticleMatch(
+                a.Id, a.Title,
+                Jaccard(ticketTokens, Tokenize($"{a.Content} {a.Tags}"))))
+            .Where(m => m.Score > 0)
+            .OrderByDescending(m => m.Score)
+            .Take(topN)
+            .ToList();
+    }
+
+    private static double Jaccard(HashSet<string> a, HashSet<string> b)
+    {
+        if (a.Count == 0 && b.Count == 0) return 0;
+        var intersection = a.Intersect(b).Count();
+        var union = a.Union(b).Count();
+        return intersection / (double)union;
     }
 
     private static readonly char[] _punctuation =


### PR DESCRIPTION
Closes #396

## Summary

Eliminates the duplicated tokenization logic in `ResolveEndpoints.cs` by delegating article scoring to `MatchingService`.

## PRD Fidelity

Issue #396 is an auto-generated refactoring/bug report (not from a PRD decomposition). No PRD drift applies.

## Changes

- **`PRDtoProd/DTOs/ResolveDtos.cs`** (new) — Moved `ArticleMatch` and `ResolveResponse` records out of the endpoint layer into the shared DTOs namespace so `MatchingService` can reference them.
- **`PRDtoProd/Services/MatchingService.cs`** — Added `GetTopMatches(Ticket, IEnumerable(KnowledgeArticle), int topN = 3)` public method that uses the service's superior `Tokenize` (with punctuation stripping + length filtering) and Jaccard scoring.
- **`PRDtoProd/Endpoints/ResolveEndpoints.cs`** — Removed private `Tokenize` and `Jaccard` helpers; replaced inline article-scoring loop with a call to `matcher.GetTopMatches`.
- **`PRDtoProd.Tests/MatchingServiceTests.cs`** — Added 3 tests: `GetTopMatches_ReturnsRankedMatches`, `GetTopMatches_NoMatchingArticle_ReturnsEmpty`, `GetTopMatches_RespectsTopN`.

## Impact

- `/api/tickets/{id}/resolve` response structure is unchanged.
- Tokenization quality for confidence-score computation is now **improved** (punctuation stripped, empty tokens filtered) — the service's `Tokenize` is strictly better than the old endpoint version.
- Any future change to tokenization only needs to be made in one place.

## Test Results

```
Test Run Successful.
Total tests: 158
     Passed: 158
Total time: 11.05 Seconds
```

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22759503819) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+repo-assist%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22759503819, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22759503819 -->

<!-- gh-aw-workflow-id: repo-assist -->