### PR TITLE
[Pipeline] Fix RunHistoryTests: correct assertions and stub registration

### DIFF
--- a/PRDtoProd.Tests/RunHistoryTests.cs
+++ b/PRDtoProd.Tests/RunHistoryTests.cs
@@ -29,11 +29,9 @@ public class RunHistoryTests
             {
                 TestFactoryExtensions.ReplaceDbWithInMemory(services, $"TestDb_{Guid.NewGuid()}");
 
-                // Remove the real ShowcaseService and replace with stub
-                var descriptor = services.SingleOrDefault(
-                    d => d.ServiceType == typeof(IShowcaseService));
-                if (descriptor != null)
-                    services.Remove(descriptor);
+                // Remove all IShowcaseService registrations and replace with stub
+                foreach (var d in services.Where(d => d.ServiceType == typeof(IShowcaseService)).ToList())
+                    services.Remove(d);
 
                 services.AddSingleton<IShowcaseService>(new StubShowcaseService(runs));
             });
@@ -65,7 +63,11 @@ public class RunHistoryTests
         var client = factory.CreateClient();
         var html = await client.GetStringAsync("/");
 
-        Assert.Contains("0 pipeline runs", html);
+        // The evidence strip renders value and label in separate divs:
+        // <div class="evidence-val">0</div>
+        // <div class="evidence-lbl">pipeline runs</div>
+        Assert.Contains("pipeline runs", html);
+        Assert.Contains("class=\"evidence-val\">0<", html);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #399

## Summary

Fixes 2 failing tests in `PRDtoProd.Tests.RunHistoryTests` that caused CI to fail on `main`.

## Root Cause

**`EvidenceStrip_ShowsZeroWhenNoRuns`** — The assertion `Assert.Contains("0 pipeline runs", html)` can never pass because the evidence strip renders value and label in *separate* `(div)` elements:
```html
(div class="evidence-val")0(/div)
(div class="evidence-lbl")pipeline runs(/div)
```
The string `"0 pipeline runs"` is never a contiguous substring of the HTML.

**`EvidenceStrip_TotalsMatchAggregatedData`** — `CreateFactory` used `services.SingleOrDefault(...)` to find and remove the `IShowcaseService` registration. `SingleOrDefault` throws `InvalidOperationException` if more than one matching descriptor is present, and silently skips removal if the wrong descriptor is returned. This could leave the real `ShowcaseService` in place (which reads from the filesystem and returns actual showcase data), causing `TotalIssues` to be ≠ 10 and making `Assert.Contains("10+", html)` fail.

## Changes

- **`PRDtoProd.Tests/RunHistoryTests.cs`**
  - `CreateFactory`: Replace `SingleOrDefault` + `Remove` with a `Where(...).ToList()` loop that removes *all* `IShowcaseService` descriptors, then adds the stub. More robust and avoids throwing on multiple registrations.
  - `EvidenceStrip_ShowsZeroWhenNoRuns`: Replace `Assert.Contains("0 pipeline runs", html)` with two targeted assertions that match the actual HTML structure:
    - `Assert.Contains("pipeline runs", html)` — label is rendered
    - `Assert.Contains("class=\"evidence-val\">0<", html)` — value div contains `0`

## PRD Fidelity

No PRD involved — this is a CI bug fix for tests introduced by PR #393.

## Test Results

Changes are minimal and surgical — only test assertions and the factory stub setup are modified. No production code changed. CI will validate.

---

*This PR was created by Pipeline Assistant.*




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22760214221) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+repo-assist%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22760214221, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22760214221 -->

<!-- gh-aw-workflow-id: repo-assist -->