### PR TITLE
[code-simplifier] refactor: use IReadOnlyList in ResolveResponse DTO

### DIFF
--- a/PRDtoProd/DTOs/ResolveDtos.cs
+++ b/PRDtoProd/DTOs/ResolveDtos.cs
@@ -1,4 +1,4 @@
 namespace PRDtoProd.DTOs;
 
 public record ArticleMatch(Guid ArticleId, string Title, double Score);
-public record ResolveResponse(TicketResponse Ticket, List<ArticleMatch> Matches);
+public record ResolveResponse(TicketResponse Ticket, IReadOnlyList<ArticleMatch> Matches);

--- a/PRDtoProd/Endpoints/ResolveEndpoints.cs
+++ b/PRDtoProd/Endpoints/ResolveEndpoints.cs
@@ -23,9 +23,8 @@ public static class ResolveEndpoints
         matcher.ResolveTicket(ticket, db);
         await db.SaveChangesAsync();
 
-        // Compute confidence scores for response via the service layer
         var articles = db.KnowledgeArticles.ToList();
-        var matches = matcher.GetTopMatches(ticket, articles).ToList();
+        var matches = matcher.GetTopMatches(ticket, articles);
 
         var ticketResponse = ticket.ToResponse();
 


### PR DESCRIPTION
Simplifies recently modified code from PR #398 (tokenization consolidation) to improve type consistency and eliminate a redundant allocation.

### Files Simplified

- `PRDtoProd/DTOs/ResolveDtos.cs` — Changed `Matches` from `List(ArticleMatch)` to `IReadOnlyList(ArticleMatch)`
- `PRDtoProd/Endpoints/ResolveEndpoints.cs` — Removed redundant `.ToList()` call and an obvious comment

### Improvements Made

**Eliminated unnecessary allocation**
`GetTopMatches` already returns `IReadOnlyList(ArticleMatch)` (backed by a `List(T)` internally). The `ResolveResponse` DTO declared `List(ArticleMatch)`, forcing a second `.ToList()` copy in the endpoint for no benefit.

**Better type signaling**
Response DTOs should communicate read-only intent. `IReadOnlyList(ArticleMatch)` makes clear that callers (e.g., JSON serializers, test assertions) should not mutate the collection — which matches actual usage.

**Removed obvious comment**
Removed `// Compute confidence scores for response via the service layer` — the code already expresses this clearly. Aligns with AGENTS.md: "Add comments only for non-obvious logic."

### Changes Based On

Recent changes from:
- #398 — [Pipeline] Consolidate tokenization logic into MatchingService
- #404 — [Pipeline] Fix EvidenceStrip HTML encoding of '+' character in Index page

### Testing

- ✅ Build succeeds (`dotnet build PRDtoProd.sln -c Release`)
- ✅ No functional changes — behavior is identical (JSON serialization of `IReadOnlyList` is identical to `List`)

### Review Focus

Please verify:
- `IReadOnlyList(ArticleMatch)` serializes correctly in the `/api/tickets/{id}/resolve` response
- No consumers of `ResolveResponse.Matches` require a mutable `List(T)`

---

*Automated by Code Simplifier Agent — analyzing code from the last 24 hours*


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22781787650) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 7 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `crl3.digicert.com`
> - `crl4.digicert.com`
> - `ocsp.digicert.com`
> - `s.symcb.com`
> - `s.symcd.com`
> - `tscrl.ws.symantec.com`
> - `tsocsp.ws.symantec.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "crl3.digicert.com"
>     - "crl4.digicert.com"
>     - "ocsp.digicert.com"
>     - "s.symcb.com"
>     - "s.symcd.com"
>     - "tscrl.ws.symantec.com"
>     - "tsocsp.ws.symantec.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> - [x] expires <!-- gh-aw-expires: 2026-03-07T21:07:58.017Z --> on Mar 7, 2026, 9:07 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 22781787650, workflow_id: code-simplifier, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22781787650 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->