### PR TITLE
[Pipeline] Extract compliance decisions lookup into shared ComplianceQueries helper

### DIFF
--- a/PRDtoProd/Data/ComplianceQueries.cs
+++ b/PRDtoProd/Data/ComplianceQueries.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+using Microsoft.EntityFrameworkCore;
+using PRDtoProd.Models;
+
+namespace PRDtoProd.Data;
+
+public static class ComplianceQueries
+{
+    // SQLite cannot translate DateTimeOffset ORDER BY, so timestamp ordering happens in memory.
+    public static async Task<Dictionary<Guid, ComplianceDecisionType?>> GetLatestDecisionsAsync(
+        TicketDbContext db)
+    {
+        var decisions = await db.ComplianceDecisions
+            .AsNoTracking()
+            .Select(d => new { d.ScanId, d.Decision, d.DecidedAt })
+            .ToListAsync();
+        return decisions
+            .GroupBy(d => d.ScanId)
+            .ToDictionary(
+                g => g.Key,
+                g => g
+                    .OrderByDescending(d => d.DecidedAt)
+                    .Select(d => (ComplianceDecisionType?)d.Decision)
+                    .FirstOrDefault());
+    }
+}

--- a/PRDtoProd/Endpoints/ComplianceEndpoints.cs
+++ b/PRDtoProd/Endpoints/ComplianceEndpoints.cs
@@ -62,19 +62,7 @@ public static class ComplianceEndpoints
 
     private static async Task<IResult> GetAllScans(TicketDbContext db)
     {
-        // SQLite cannot translate DateTimeOffset ORDER BY, so timestamp ordering happens in memory.
-        var decisions = await db.ComplianceDecisions
-            .AsNoTracking()
-            .Select(d => new { d.ScanId, d.Decision, d.DecidedAt })
-            .ToListAsync();
-        var decisionLookup = decisions
-            .GroupBy(d => d.ScanId)
-            .ToDictionary(
-                g => g.Key,
-                g => g
-                    .OrderByDescending(d => d.DecidedAt)
-                    .Select(d => (ComplianceDecisionType?)d.Decision)
-                    .FirstOrDefault());
+        var decisionLookup = await ComplianceQueries.GetLatestDecisionsAsync(db);
 
         var scans = await db.ComplianceScans
             .AsNoTracking()

--- a/PRDtoProd/Pages/Compliance.cshtml.cs
+++ b/PRDtoProd/Pages/Compliance.cshtml.cs
@@ -26,15 +26,7 @@ public class ComplianceModel : PageModel
 
     public async Task OnGetAsync()
     {
-        // SQLite cannot translate DateTimeOffset ORDER BY, so decision ordering happens in memory.
-        var latestDecisions = (await _db.ComplianceDecisions
-            .AsNoTracking()
-            .Select(d => new { d.ScanId, d.Decision, d.DecidedAt })
-            .ToListAsync())
-            .GroupBy(d => d.ScanId)
-            .ToDictionary(
-                g => g.Key,
-                g => g.OrderByDescending(d => d.DecidedAt).First().Decision);
+        var latestDecisions = await ComplianceQueries.GetLatestDecisionsAsync(_db);
 
         var approvedScanIds = latestDecisions
             .Where(kv => kv.Value == ComplianceDecisionType.Approved)


### PR DESCRIPTION
Closes #406

## Summary

Eliminates duplicate latest-decision-per-scan query logic that existed independently in both `ComplianceEndpoints.cs` and `Compliance.cshtml.cs`.

## Changes

- **`PRDtoProd/Data/ComplianceQueries.cs`** _(new)_ — static `GetLatestDecisionsAsync(TicketDbContext)` helper that encapsulates the decisions query, in-memory grouping, and `OrderByDescending` tie-breaking
- **`ComplianceEndpoints.GetAllScans`** — replaced 11-line inline block with a single `await ComplianceQueries.GetLatestDecisionsAsync(db)` call
- **`Compliance.cshtml.cs OnGetAsync`** — replaced 9-line inline block with the same shared call; also fixes a latent null-safety bug (page model was using `.First()` which throws if the group is somehow empty; now uses `.FirstOrDefault()` consistently)

## PRD Fidelity

No PRD traceability section — this is a code quality / bug issue (`#406`) identified by the Duplicate Code Detector workflow, not a PRD-decomposed feature. The fix is purely internal; no API contracts or page behaviour are changed.

## Test Results

```
Build succeeded. 0 Warning(s), 0 Error(s).
Passed! Failed: 0, Passed: 165, Skipped: 0, Total: 165
```

---

_This PR was created by Pipeline Assistant._




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22797191122) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+repo-assist%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22797191122, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22797191122 -->

<!-- gh-aw-workflow-id: repo-assist -->