### PR TITLE
fix: harden pipeline incident and duplicate PR handling

### DIFF
--- a/.github/workflows/auto-dispatch-requeue.yml
+++ b/.github/workflows/auto-dispatch-requeue.yml
@@ -93,7 +93,8 @@ jobs:
           fi
 
           OPEN_PRS=$(gh pr list --repo "$REPO" --state open --limit 100 --json body 2>/dev/null || echo '[]')
-          LINKED_ISSUES=$(printf '%s' "$OPEN_PRS" | jq -r '[.[] | (.body // "") | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | .[][]? ' 2>/dev/null || true)
+          LINKED_ISSUES=$(printf '%s' "$OPEN_PRS" | jq -r '.[].body // empty' 2>/dev/null \
+            | bash scripts/extract-linked-issue-numbers.sh "$REPO" || true)
           PIPELINE_ISSUES=$(gh issue list --repo "$REPO" --label pipeline --state open --limit 200 \
             --json number,title,createdAt,labels 2>/dev/null || echo '[]')
 

--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -386,7 +386,9 @@ jobs:
             exit 0
           fi
 
-          LINKED_ISSUE=$(printf '%s' "$PR_JSON" | jq -r '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | first | .[]? // empty' | head -1)
+          LINKED_ISSUE=$(printf '%s' "$PR_JSON" | jq -r '.body // ""' \
+            | bash scripts/extract-linked-issue-numbers.sh "$REPO" \
+            | head -1 || true)
           if [ -z "$LINKED_ISSUE" ]; then
             TITLE="[CI Incident] PR #${PR_NUMBER} CI Failure: ${SHORT_SUMMARY}"
             BODY=$(render_incident_body \

--- a/.github/workflows/ci-failure-resolve.yml
+++ b/.github/workflows/ci-failure-resolve.yml
@@ -10,6 +10,8 @@ on:
   workflow_run:
     workflows: [".NET CI", "Node CI", "Docker CI", "Deploy Router", "Deploy to Azure"]
     types: [completed]
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: read
@@ -18,13 +20,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: "ci-failure-resolve-${{ github.event.workflow_run.id }}"
+  group: "ci-failure-resolve-${{ github.event.workflow_run.id || github.event.pull_request.number || github.run_id }}"
   cancel-in-progress: false
 
 jobs:
   resolve-failure:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 10
     steps:
       - name: Checkout repository helpers
@@ -200,6 +202,7 @@ jobs:
   close-cookie-issues:
     runs-on: ubuntu-latest
     if: >-
+      github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main'
     timeout-minutes: 5
@@ -223,4 +226,84 @@ jobs:
             gh issue close "$ISSUE_NUMBER" --repo "$REPO" \
               --comment "CI is green on main (${SUCCESS_RUN_URL}). Closing diagnostic issue as resolved." || \
               echo "::warning::Failed to close cookie issue #${ISSUE_NUMBER}"
+          done
+
+  close-pr-incidents-on-success:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 5
+    steps:
+      - name: Close PR-scoped CI incident issues on successful CI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SUCCESS_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PULL_REQUESTS_JSON: ${{ toJson(github.event.workflow_run.pull_requests) }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER=$(printf '%s' "$PULL_REQUESTS_JSON" | jq -r '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Successful CI run is not attached to a PR. No PR-scoped incidents to close."
+            exit 0
+          fi
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,headRefOid 2>/dev/null || echo '{}')
+          PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state // ""')
+          CURRENT_HEAD_SHA=$(printf '%s' "$PR_JSON" | jq -r '.headRefOid // ""')
+
+          if [ "$PR_STATE" = "OPEN" ] && [ -n "$CURRENT_HEAD_SHA" ] && [ "$CURRENT_HEAD_SHA" != "$HEAD_SHA" ]; then
+            echo "Successful run head ${HEAD_SHA} is stale versus PR head ${CURRENT_HEAD_SHA}. Leaving incidents open."
+            exit 0
+          fi
+
+          ISSUES=$(gh issue list --repo "$REPO" --state open --label ci-failure --limit 200 --json number,title \
+            | jq -r --arg pr "$PR_NUMBER" '.[] | select(.title | test("^\\[CI Incident\\](?: Escalation:)? PR #" + $pr + "\\b")) | .number')
+
+          if [ -z "$ISSUES" ]; then
+            echo "No open PR-scoped CI incidents found for PR #${PR_NUMBER}."
+            exit 0
+          fi
+
+          for ISSUE_NUMBER in $ISSUES; do
+            echo "Closing PR-scoped CI incident #${ISSUE_NUMBER}..."
+            gh issue close "$ISSUE_NUMBER" --repo "$REPO" \
+              --comment "CI recovered for PR #${PR_NUMBER} on ${SUCCESS_RUN_URL}. Closing PR-scoped incident as resolved." || \
+              echo "::warning::Failed to close PR-scoped CI incident #${ISSUE_NUMBER}"
+          done
+
+  close-pr-incidents-on-pr-close:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    timeout-minutes: 5
+    steps:
+      - name: Close PR-scoped CI incident issues when the PR closes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+        run: |
+          set -euo pipefail
+
+          ISSUES=$(gh issue list --repo "$REPO" --state open --label ci-failure --limit 200 --json number,title \
+            | jq -r --arg pr "$PR_NUMBER" '.[] | select(.title | test("^\\[CI Incident\\](?: Escalation:)? PR #" + $pr + "\\b")) | .number')
+
+          if [ -z "$ISSUES" ]; then
+            echo "No open PR-scoped CI incidents found for PR #${PR_NUMBER}."
+            exit 0
+          fi
+
+          if [ "$PR_MERGED" = "true" ]; then
+            COMMENT="PR #${PR_NUMBER} merged (${PR_URL}). Closing PR-scoped incident as stale."
+          else
+            COMMENT="PR #${PR_NUMBER} closed without merge (${PR_URL}). Closing PR-scoped incident as stale."
+          fi
+
+          for ISSUE_NUMBER in $ISSUES; do
+            echo "Closing PR-scoped CI incident #${ISSUE_NUMBER}..."
+            gh issue close "$ISSUE_NUMBER" --repo "$REPO" --comment "$COMMENT" || \
+              echo "::warning::Failed to close PR-scoped CI incident #${ISSUE_NUMBER}"
           done

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -12,6 +12,7 @@ on:
     types: [closed]
 
 permissions:
+  contents: read
   issues: write
   pull-requests: read
 
@@ -25,6 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/extract-linked-issue-numbers.sh
+          sparse-checkout-cone-mode: false
+
       - name: Close linked issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,9 +39,8 @@ jobs:
           PR_NUMBER="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
 
-          # Extract issue numbers entirely within jq — zero shell exposure to PR body
-          ISSUES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body \
-            --jq '[.body | scan("(?i)(?:closes|close|fix|fixes|resolve|resolves)\\s+#(\\d+)")] | .[][] ')
+          ISSUES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""' \
+            | bash scripts/extract-linked-issue-numbers.sh "$REPO")
 
           if [ -z "$ISSUES" ]; then
             echo "No issue-closing references found in PR #${PR_NUMBER} body."

--- a/.github/workflows/duplicate-code-detector.lock.yml
+++ b/.github/workflows/duplicate-code-detector.lock.yml
@@ -323,7 +323,7 @@ jobs:
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 1 issue(s) can be created. Assignees [\"copilot\"] will be automatically assigned.",
+              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 1 issue(s) can be created.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -1095,8 +1095,8 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"assignees\":[\"copilot\"],\"max\":1},\"missing_data\":{},\"missing_tool\":{}}"
-          GH_AW_ASSIGN_COPILOT: "true"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"max\":1},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_ASSIGN_COPILOT: "false"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1123,4 +1123,3 @@ jobs:
           name: safe-output-items
           path: /tmp/safe-output-items.jsonl
           if-no-files-found: warn
-

--- a/.github/workflows/duplicate-code-detector.md
+++ b/.github/workflows/duplicate-code-detector.md
@@ -16,7 +16,6 @@ safe-outputs:
     expires: 2d
     title-prefix: "[duplicate-code] "
     labels: [code-quality, automated-analysis, cookie]
-    assignees: copilot
     group: true
     max: 3
 tools:
@@ -188,7 +187,7 @@ For each distinct duplication pattern found, create a separate issue using this 
 
 *Analysis of commit ${{ github.event.head_commit.id }}*
 
-**Assignee**: @copilot
+**Route**: Pipeline auto-dispatch
 
 ## Summary
 
@@ -265,7 +264,7 @@ For each distinct duplication pattern found, create a separate issue using this 
 - Include sufficient detail for SWE agents to understand and act on findings
 - Provide concrete examples with file paths and line numbers
 - Suggest practical refactoring approaches
-- Assign issue to @copilot for automated remediation
+- Leave the issue unassigned so pipeline routing can claim it deterministically
 - Use descriptive titles that clearly identify the specific pattern (e.g., "Duplicate Code: Error Handling Pattern in Parser Module")
 - **If no significant duplication found, call `noop` tool** - never complete without calling either `create_issue` or `noop`
 

--- a/.github/workflows/pr-review-submit.yml
+++ b/.github/workflows/pr-review-submit.yml
@@ -82,6 +82,7 @@ jobs:
             scripts/healing-control.sh
             scripts/check-autonomy-policy.sh
             scripts/classify-pipeline-pr.sh
+            scripts/extract-linked-issue-numbers.sh
             autonomy-policy.yml
           sparse-checkout-cone-mode: false
 
@@ -156,9 +157,8 @@ jobs:
           PR_TITLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq '.title')
           echo "pr_title=${PR_TITLE}" >> "$GITHUB_OUTPUT"
 
-          # Extract linked issue number from PR body via jq (zero shell exposure to body)
-          ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body \
-            --jq '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | first | .[]? // empty' \
+          ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""' \
+            | bash scripts/extract-linked-issue-numbers.sh "$REPO" \
             | head -1 || true)
           echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
 
@@ -439,7 +439,8 @@ jobs:
                   if ! printf '%s' "$pr" | bash scripts/classify-pipeline-pr.sh | jq -e '.pipeline_pr == true' >/dev/null; then
                     continue
                   fi
-                  if printf '%s' "$pr" | jq -e --arg issue "$ISSUE_NUMBER" '(.body // "") | test("(?i)(close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#" + $issue + "\\b")' >/dev/null; then
+                  CANDIDATE_BODY=$(printf '%s' "$pr" | jq -r '.body // ""')
+                  if printf '%s' "$CANDIDATE_BODY" | bash scripts/extract-linked-issue-numbers.sh "$REPO" | grep -qx "$ISSUE_NUMBER"; then
                     echo "$CANDIDATE_NUMBER"
                   fi
                 done
@@ -544,6 +545,7 @@ jobs:
             scripts/healing-control.sh
             scripts/check-autonomy-policy.sh
             scripts/classify-pipeline-pr.sh
+            scripts/extract-linked-issue-numbers.sh
             autonomy-policy.yml
           sparse-checkout-cone-mode: false
 
@@ -603,9 +605,8 @@ jobs:
           PR_TITLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq '.title')
           echo "pr_title=${PR_TITLE}" >> "$GITHUB_OUTPUT"
 
-          # Extract linked issue number from PR body
-          ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body \
-            --jq '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | first | .[]? // empty' \
+          ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""' \
+            | bash scripts/extract-linked-issue-numbers.sh "$REPO" \
             | head -1 || true)
           echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
 
@@ -815,8 +816,8 @@ jobs:
             echo "PR #${PR_NUMBER} merged. Closing linked issues."
             TARGET="${ISSUE_NUMBER:-}"
             if [ -z "$TARGET" ]; then
-              TARGET=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body \
-                --jq '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | first | .[]? // empty' \
+              TARGET=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""' \
+                | bash scripts/extract-linked-issue-numbers.sh "$REPO" \
                 | head -1 || true)
             fi
             if [ -n "$TARGET" ]; then
@@ -835,8 +836,8 @@ jobs:
             echo "::warning::Merge not observed within 120s for PR #${PR_NUMBER}."
             TARGET="${ISSUE_NUMBER:-}"
             if [ -z "$TARGET" ]; then
-              TARGET=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body \
-                --jq '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | first | .[]? // empty' \
+              TARGET=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""' \
+                | bash scripts/extract-linked-issue-numbers.sh "$REPO" \
                 | head -1 || true)
             fi
             if [ -n "$TARGET" ]; then
@@ -865,8 +866,8 @@ jobs:
 
           TARGET="${ISSUE_NUMBER:-}"
           if [ -z "$TARGET" ]; then
-            TARGET=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body \
-              --jq '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | first | .[]? // empty' \
+            TARGET=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""' \
+              | bash scripts/extract-linked-issue-numbers.sh "$REPO" \
               | head -1 || true)
           fi
           if [ -z "$TARGET" ]; then
@@ -891,7 +892,8 @@ jobs:
                   if ! printf '%s' "$pr" | bash scripts/classify-pipeline-pr.sh | jq -e '.pipeline_pr == true' >/dev/null; then
                     continue
                   fi
-                  if printf '%s' "$pr" | jq -e --arg issue "$TARGET" '(.body // "") | test("(?i)(close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#" + $issue + "\\b")' >/dev/null; then
+                  CANDIDATE_BODY=$(printf '%s' "$pr" | jq -r '.body // ""')
+                  if printf '%s' "$CANDIDATE_BODY" | bash scripts/extract-linked-issue-numbers.sh "$REPO" | grep -qx "$TARGET"; then
                     echo "$CANDIDATE_NUMBER"
                   fi
                 done
@@ -984,7 +986,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
-      startsWith(github.event.comment.body, '/approve-sensitive') &&
+      (startsWith(github.event.comment.body, '/approve-sensitive') || startsWith(github.event.comment.body, '/approve_sensitive')) &&
       github.event.comment.user.login == github.repository_owner
 
     concurrency:

--- a/scripts/extract-linked-issue-numbers.sh
+++ b/scripts/extract-linked-issue-numbers.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_REPO="${1:-}"
+
+TARGET_REPO="$TARGET_REPO" perl -0ne '
+  my $target = lc($ENV{TARGET_REPO} // q{});
+  my %seen;
+
+  while (/(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\s+(?:([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+))?#([0-9]+)\b/g) {
+    my ($repo, $issue) = ($1 // q{}, $2);
+    next if $target ne q{} && $repo ne q{} && lc($repo) ne $target;
+    next if $seen{$issue}++;
+    print "$issue\n";
+  }
+'

--- a/scripts/pipeline-watchdog.sh
+++ b/scripts/pipeline-watchdog.sh
@@ -44,6 +44,10 @@ read_marker_field() {
   printf '%s\n' "$body" | sed -n "s/^${field}=//p" | head -1
 }
 
+extract_linked_issue_numbers() {
+  bash "$SCRIPT_DIR/extract-linked-issue-numbers.sh" "$REPO"
+}
+
 find_marker_comment() {
   local item_number=$1
   local marker=$2
@@ -344,8 +348,8 @@ while IFS= read -r PR_ROW; do
     continue
   fi
 
-  ISSUE_NUM=$(gh pr view "$PR_NUM" --repo "$REPO" --json body \
-    --jq '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | first | .[]? // empty' | head -1 || true)
+  ISSUE_NUM=$(gh pr view "$PR_NUM" --repo "$REPO" --json body --jq '.body // ""' \
+    | extract_linked_issue_numbers | head -1 || true)
   if [ -z "$ISSUE_NUM" ]; then
     echo "::warning::PR #${PR_NUM} has no linked issue — cannot dispatch fix"
     continue
@@ -364,8 +368,8 @@ echo "=== Checking for orphaned issues ==="
 PIPELINE_ISSUES=$(gh issue list --repo "$REPO" --label pipeline --state open --json number,title,updatedAt,labels)
 LINKED_ISSUES=$(printf '%s' "$PIPELINE_PRS" | jq -r '.[].number' | while read -r PR_N; do
   [ -z "$PR_N" ] && continue
-  gh pr view "$PR_N" --repo "$REPO" --json body \
-    --jq '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | .[][]' 2>/dev/null || true
+  gh pr view "$PR_N" --repo "$REPO" --json body --jq '.body // ""' 2>/dev/null \
+    | extract_linked_issue_numbers || true
 done | sort -u)
 
 while IFS= read -r ISSUE_ROW; do
@@ -408,8 +412,8 @@ echo "=== Checking for superseded PRs ==="
 while IFS= read -r PR_ROW; do
   [ -z "$PR_ROW" ] && continue
   PR_NUM=$(printf '%s' "$PR_ROW" | jq -r '.number')
-  LINKED_ISSUE=$(gh pr view "$PR_NUM" --repo "$REPO" --json body \
-    --jq '[.body | scan("(?i)(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\s+#(\\d+)")] | first | .[]? // empty' | head -1 || true)
+  LINKED_ISSUE=$(gh pr view "$PR_NUM" --repo "$REPO" --json body --jq '.body // ""' \
+    | extract_linked_issue_numbers | head -1 || true)
   if [ -z "$LINKED_ISSUE" ]; then
     echo "PR #${PR_NUM}: no linked issue. Skipping."
     continue
@@ -422,7 +426,19 @@ while IFS= read -r PR_ROW; do
   fi
 
   MERGED_PR=$(gh pr list --repo "$REPO" --state merged --json number,title,body \
-    --jq "[.[] | select(.number != ${PR_NUM} and (.title | startswith(\"[Pipeline]\")) and (.body | test(\"(?i)(close[ds]?|fix(?:e[ds])?|resolve[ds]?)\\\\s+#${LINKED_ISSUE}\\\\b\")))] | first | .number // empty" | head -1 || true)
+    | jq -rc '.[]' \
+    | while read -r pr; do
+        CANDIDATE_NUM=$(printf '%s' "$pr" | jq -r '.number')
+        [ "$CANDIDATE_NUM" = "$PR_NUM" ] && continue
+        if ! printf '%s' "$pr" | jq -e '(.title // "") | startswith("[Pipeline]")' >/dev/null; then
+          continue
+        fi
+        CANDIDATE_BODY=$(printf '%s' "$pr" | jq -r '.body // ""')
+        if printf '%s' "$CANDIDATE_BODY" | extract_linked_issue_numbers | grep -qx "$LINKED_ISSUE"; then
+          echo "$CANDIDATE_NUM"
+          break
+        fi
+      done | head -1 || true)
   if [ -z "$MERGED_PR" ]; then
     echo "PR #${PR_NUM}: issue #${LINKED_ISSUE} closed but no merged [Pipeline] PR found. Skipping."
     continue

--- a/scripts/tests/test-ci-failure-resolve.sh
+++ b/scripts/tests/test-ci-failure-resolve.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+WORKFLOW="$ROOT_DIR/.github/workflows/ci-failure-resolve.yml"
+
+ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml-ok"' "$WORKFLOW" >/dev/null
+
+grep -F "pull_request:" "$WORKFLOW" >/dev/null
+grep -F "types: [closed]" "$WORKFLOW" >/dev/null
+grep -F "Close PR-scoped CI incident issues on successful CI" "$WORKFLOW" >/dev/null
+grep -F "Close PR-scoped CI incident issues when the PR closes" "$WORKFLOW" >/dev/null
+grep -F 'test("^\\[CI Incident\\](?: Escalation:)? PR #' "$WORKFLOW" >/dev/null
+
+echo "ci-failure-resolve.yml tests passed"

--- a/scripts/tests/test-duplicate-code-detector.sh
+++ b/scripts/tests/test-duplicate-code-detector.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+WORKFLOW_MD="$ROOT_DIR/.github/workflows/duplicate-code-detector.md"
+WORKFLOW_LOCK="$ROOT_DIR/.github/workflows/duplicate-code-detector.lock.yml"
+
+if grep -F "assignees: copilot" "$WORKFLOW_MD" >/dev/null; then
+  echo "FAIL: duplicate-code-detector.md should not auto-assign Copilot" >&2
+  exit 1
+fi
+
+if grep -F "**Assignee**: @copilot" "$WORKFLOW_MD" >/dev/null; then
+  echo "FAIL: duplicate-code-detector.md should not instruct Copilot assignment in the issue body" >&2
+  exit 1
+fi
+
+if grep -F "Assign issue to @copilot for automated remediation" "$WORKFLOW_MD" >/dev/null; then
+  echo "FAIL: duplicate-code-detector.md should leave issues unassigned for pipeline routing" >&2
+  exit 1
+fi
+
+if grep -F '"assignees":["copilot"]' "$WORKFLOW_LOCK" >/dev/null; then
+  echo "FAIL: duplicate-code-detector.lock.yml should not auto-assign Copilot" >&2
+  exit 1
+fi
+
+grep -F 'GH_AW_ASSIGN_COPILOT: "false"' "$WORKFLOW_LOCK" >/dev/null
+
+echo "duplicate-code-detector workflow tests passed"

--- a/scripts/tests/test-extract-linked-issue-numbers.sh
+++ b/scripts/tests/test-extract-linked-issue-numbers.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+SCRIPT="$ROOT_DIR/scripts/extract-linked-issue-numbers.sh"
+REPO="samuelkahessay/prd-to-prod"
+
+BODY=$(cat <<'EOF'
+Closes #406
+Fixes samuelkahessay/prd-to-prod#407
+Resolves other/repo#408
+Fixes #406
+EOF
+)
+
+OUTPUT=$(printf '%s' "$BODY" | bash "$SCRIPT" "$REPO")
+EXPECTED=$(printf '406\n407\n')
+
+if [ "$OUTPUT" != "$EXPECTED" ]; then
+  echo "FAIL: expected linked issue extraction to preserve order, dedupe, and ignore other repos" >&2
+  printf 'Expected:\n%s\nActual:\n%s\n' "$EXPECTED" "$OUTPUT" >&2
+  exit 1
+fi
+
+ALL_OUTPUT=$(printf '%s' "$BODY" | bash "$SCRIPT")
+printf '%s\n' "$ALL_OUTPUT" | grep -qx '408'
+
+echo "extract-linked-issue-numbers.sh tests passed"

--- a/scripts/tests/test-pr-review-submit-policy-gate.sh
+++ b/scripts/tests/test-pr-review-submit-policy-gate.sh
@@ -8,6 +8,7 @@ ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml-ok"' "$WORKFLOW" >/
 
 grep -F "scripts/check-autonomy-policy.sh" "$WORKFLOW" >/dev/null
 grep -F "scripts/classify-pipeline-pr.sh" "$WORKFLOW" >/dev/null
+grep -F "scripts/extract-linked-issue-numbers.sh" "$WORKFLOW" >/dev/null
 grep -F "autonomy-policy.yml" "$WORKFLOW" >/dev/null
 grep -F "policy_artifact_change" "$WORKFLOW" >/dev/null
 grep -F "workflow_file_change" "$WORKFLOW" >/dev/null
@@ -17,6 +18,7 @@ grep -F "AUTO_FOLLOW_UP_ALLOWED" "$WORKFLOW" >/dev/null
 grep -F "Skipping autonomous merge for PR classification:" "$WORKFLOW" >/dev/null
 grep -F "Autonomous merge blocked by autonomy policy." "$WORKFLOW" >/dev/null
 grep -F "bug\" or . == \"docs\" or . == \"test\"" "$WORKFLOW" >/dev/null
+grep -F "startsWith(github.event.comment.body, '/approve_sensitive')" "$WORKFLOW" >/dev/null
 grep -F 'Cannot use \`/approve-sensitive\` here.' "$WORKFLOW" >/dev/null
 grep -F 'no active \`sensitive_app_change\` policy match' "$WORKFLOW" >/dev/null
 grep -F 'BLOCKING_ACTION="$ACTION"' "$WORKFLOW" >/dev/null

--- a/scripts/tests/test-verify-mvp.sh
+++ b/scripts/tests/test-verify-mvp.sh
@@ -33,9 +33,12 @@ run_and_capture() {
 DEFAULT_CALLS=$(run_and_capture)
 printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-auto-dispatch.sh" >/dev/null
 printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-check-autonomy-policy.sh" >/dev/null
+printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-ci-failure-resolve.sh" >/dev/null
 printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-log-decision.sh" >/dev/null
 printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-pipeline-watchdog.sh" >/dev/null
 printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-classify-pipeline-pr.sh" >/dev/null
+printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-duplicate-code-detector.sh" >/dev/null
+printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-extract-linked-issue-numbers.sh" >/dev/null
 printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-patch-pr-review-agent-lock.sh" >/dev/null
 printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-pr-review-agent-activation.sh" >/dev/null
 printf '%s\n' "$DEFAULT_CALLS" | grep -F "bash scripts/tests/test-pr-review-submit-policy-gate.sh" >/dev/null

--- a/scripts/verify-mvp.sh
+++ b/scripts/verify-mvp.sh
@@ -39,9 +39,12 @@ done
 CHECKS=(
   "bash scripts/tests/test-auto-dispatch.sh"
   "bash scripts/tests/test-check-autonomy-policy.sh"
+  "bash scripts/tests/test-ci-failure-resolve.sh"
   "bash scripts/tests/test-ci-failure-context.sh"
   "bash scripts/tests/test-classify-pipeline-issue.sh"
   "bash scripts/tests/test-classify-pipeline-pr.sh"
+  "bash scripts/tests/test-duplicate-code-detector.sh"
+  "bash scripts/tests/test-extract-linked-issue-numbers.sh"
   "bash scripts/tests/test-log-decision.sh"
   "bash scripts/tests/test-pipeline-watchdog.sh"
   "bash scripts/tests/test-patch-pr-review-agent-lock.sh"


### PR DESCRIPTION
Closes #409

## Summary
This PR hardens the pipeline around three failure modes found during the March 7, 2026 investigation:

- sensitive-path approval handling now accepts both `/approve-sensitive` and `/approve_sensitive`
- PR-scoped CI incident issues now close when CI recovers or when the underlying PR closes
- duplicate-code detector no longer auto-assigns Copilot, which was creating competing duplicate PRs

## Changes

- added a shared `scripts/extract-linked-issue-numbers.sh` helper and reused it across review, close-issue, watchdog, and requeue flows so repo-qualified issue references are handled consistently
- updated `pr-review-submit.yml` to support both sensitive approval spellings and to use the shared linked-issue parser during duplicate cleanup
- updated `ci-failure-resolve.yml` to close stale PR-scoped CI incident issues on successful CI and on PR close
- updated `duplicate-code-detector.md` and `duplicate-code-detector.lock.yml` to stop assigning Copilot to newly created duplicate-code issues
- expanded workflow/script coverage with targeted tests for linked-issue parsing, CI incident resolution, and duplicate-code detector behavior

## Test Results

- `bash scripts/tests/test-extract-linked-issue-numbers.sh`
- `bash scripts/tests/test-ci-failure-resolve.sh`
- `bash scripts/tests/test-duplicate-code-detector.sh`
- `bash scripts/tests/test-pr-review-submit-policy-gate.sh`
- `bash scripts/tests/test-pipeline-watchdog.sh`
- `bash scripts/tests/test-verify-mvp.sh`
- `ruby -e 'require "yaml"; %w[.github/workflows/pr-review-submit.yml .github/workflows/close-issues.yml .github/workflows/ci-failure-issue.yml .github/workflows/ci-failure-resolve.yml .github/workflows/auto-dispatch-requeue.yml .github/workflows/duplicate-code-detector.lock.yml].each { |f| YAML.load_file(f) }; puts "yaml-ok"'`

---

This PR was prepared with Codex.
