### PR TITLE
[Pipeline] fix: restore test-contract UI text and CSS class names

### DIFF
--- a/PRDtoProd/Pages/Index.cshtml
+++ b/PRDtoProd/Pages/Index.cshtml
@@ -145,7 +145,7 @@
     <!-- Evidence strip -->
     <section aria-label="Pipeline statistics" class="data-grid" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));">
         <div class="data-cell">
-            <div class="metric-val">@Model.TotalRuns</div>
+            <div class="evidence-val">@Model.TotalRuns</div>
             <div class="metric-lbl">pipeline runs</div>
         </div>
         <div class="data-cell">

--- a/PRDtoProd/Pages/Operator.cshtml
+++ b/PRDtoProd/Pages/Operator.cshtml
@@ -188,7 +188,7 @@
             <div class="section-header">
                 <div>
                     <div class="section-label">// blocked actions</div>
-                    <h2 id="blocked-heading">Human-Required Refusals</h2>
+                    <h2 id="blocked-heading">Human-required refusals</h2>
                 </div>
                 <span class="badge badge-red">@Model.Queue.Blocked.Count BLOCKED</span>
             </div>
@@ -226,7 +226,7 @@
             <div class="section-header">
                 <div>
                     <div class="section-label">// human queue</div>
-                    <h2 id="queued-heading">Waiting on Operator</h2>
+                    <h2 id="queued-heading">Waiting on an operator</h2>
                 </div>
                 <span class="badge badge-amber">@Model.Queue.QueuedForHuman.Count QUEUED</span>
             </div>
@@ -289,7 +289,7 @@
                 <summary class="section-header" style="cursor: pointer; list-style: none;">
                     <div>
                         <div class="section-label">// autonomous lane</div>
-                        <h2 id="autonomous-heading">Recent Autonomous</h2>
+                        <h2 id="autonomous-heading">Recent autonomous actions</h2>
                     </div>
                     <span class="badge badge-green">@Model.Queue.RecentAutonomous.Count ACTED</span>
                 </summary>
@@ -351,7 +351,7 @@
         <div class="section-header">
             <div>
                 <div class="section-label">// past runs</div>
-                <h2 id="past-runs-heading">Historical Runs</h2>
+                <h2 id="past-runs-heading">Past Runs</h2>
             </div>
             <span class="badge badge-blue">@Model.DrillRuns.Count RUNS</span>
         </div>
@@ -384,6 +384,10 @@
                             </div>
                             <div class="log-record-meta">
                                 <span class="code-pill">@run.DrillType</span>
+                                @if (!string.IsNullOrEmpty(run.FailureSignature))
+                                {
+                                    <span class="code-pill">@run.FailureSignature</span>
+                                }
                                 <span style="margin-left: var(--sp-md);">
                                     @stageSummary.CompletedCount/@totalStages complete 
                                     (@durationText)
@@ -429,7 +433,7 @@
         <div style="margin-top: var(--sp-2xl);">
             <details>
                 <summary class="section-label" style="cursor: pointer; list-style: none;">
-                    [+] Show evidence trail (@Model.DecisionTrail.Count entries)
+                    [+] Show decision trail (@Model.DecisionTrail.Count entries)
                 </summary>
                 <div style="border-left: 2px solid var(--color-border-heavy); padding-left: var(--sp-md); margin-top: var(--sp-md); display: flex; flex-direction: column; gap: var(--sp-md);">
                     @foreach (var decision in Model.DecisionTrail)

--- a/PRDtoProd/Pages/Pipeline.cshtml
+++ b/PRDtoProd/Pages/Pipeline.cshtml
@@ -121,7 +121,7 @@
 
     /* Event log timeline */
     .event-log {
-        height: 32rem;
+        height: 24rem;
         overflow-y: auto;
         overflow-anchor: none;
         border: 1px solid var(--color-border);
@@ -445,7 +445,7 @@
                             <h2>Pipeline activity</h2>
                         </div>
                     </div>
-                    <div id="eventLog" class="event-log"></div>
+                    <div id="eventLog" class="event-log text-sm"></div>
                 </section>
             </div>
         </div>

--- a/PRDtoProd/Pages/Shared/_Layout.cshtml
+++ b/PRDtoProd/Pages/Shared/_Layout.cshtml
@@ -27,12 +27,12 @@
 
     <nav aria-label="Main navigation" class="sys-nav">
         <div class="sys-nav-inner flex-row">
-            <div class="sys-brand">
+            <div class="sys-brand status-bar-brand-row">
                 <span class="sys-title">@(ViewData["NavTitle"] ?? "PRD-TO-PROD")</span>
                 <span class="sys-divider" aria-hidden="true">&nbsp;|&nbsp;</span>
                 <a href="https://github.com/samuelkahessay/prd-to-prod" target="_blank" rel="noopener noreferrer" class="sys-nav-link" aria-label="View source on GitHub">GitHub</a>
             </div>
-            <div class="sys-links" role="list">
+            <div class="sys-links status-bar-links" role="list">
                 @foreach (var item in navItems)
                 {
                     <a href="@item.Href" class="sys-nav-link @(path == item.Href ? "active" : "")">@item.Label</a>

--- a/PRDtoProd/wwwroot/css/site.css
+++ b/PRDtoProd/wwwroot/css/site.css
@@ -204,6 +204,11 @@ a {
     color: var(--color-bg-base);
     background: var(--color-text-primary);
 }
+.status-bar-links {
+    flex-wrap: wrap;
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
 
 /* ===== Brutalist Footer ===== */
 .site-footer {
@@ -254,7 +259,7 @@ a {
 .data-cell-red { border-top: 4px solid var(--color-danger); }
 
 /* ===== Metrics Typography ===== */
-.metric-val {
+.metric-val, .evidence-val {
     font-family: var(--mono);
     color: var(--color-text-primary);
     font-size: var(--fs-3xl);


### PR DESCRIPTION
Closes #411

## Summary

This PR fixes 6 failing CI tests on `main` that resulted from UI text and CSS class name mismatches between the implementation and the tests.

## PRD Fidelity

No PRD drift — this is a regression fix aligned with existing test contracts.

## Changes

| File | Change |
|------|--------|
| `Pipeline.cshtml` | Revert `.event-log` height to `24rem`; add `text-sm` class to `#eventLog` div |
| `_Layout.cshtml` | Add `status-bar-brand-row` to brand div, `status-bar-links` to nav links div |
| `site.css` | Add `.status-bar-links` flex rules (`flex-wrap`, `flex: 0 0 auto`, `white-space: nowrap`); alias `.evidence-val` = `.metric-val` |
| `Index.cshtml` | Use `evidence-val` class for pipeline runs stat |
| `Operator.cshtml` | Align section headings to test-specified text; add `FailureSignature` code-pill; rename "evidence trail" → "decision trail" |

## Tests Fixed

- `PipelinePageTests.PipelinePage_KeepsReplayEventLogHeightStable` — height 24rem ✅
- `NavigationLayoutTests.SharedNavigation_RendersDedicatedLinkRowWithDistinctTargets` — status-bar-brand-row ✅
- `NavigationLayoutTests.SharedNavigation_CssPreventsNavLinksFromShrinkingIntoNeighborTargets` — .status-bar-links CSS ✅
- `RunHistoryTests.EvidenceStrip_ShowsZeroWhenNoRuns` — evidence-val class ✅
- `OperatorPageTests.Operator_RendersBlockedQueuedAndAutonomousSections` — heading text ✅
- `OperatorPageTests.Operator_RendersPastRunsSection` — Past Runs heading + failure signature ✅

## Test Results

```
Test Run Successful.
Passed: 165
```

This PR was created by Pipeline Assistant.




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22805615359) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+repo-assist%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22805615359, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22805615359 -->

<!-- gh-aw-workflow-id: repo-assist -->