### PR TITLE
[Pipeline] fix: restore avg PRD-to-PR metric in evidence strip

### DIFF
--- a/PRDtoProd/Pages/Index.cshtml
+++ b/PRDtoProd/Pages/Index.cshtml
@@ -160,6 +160,10 @@
             <div class="metric-val">&lt;1h</div>
             <div class="metric-lbl">fastest PRD-to-ship</div>
         </div>
+        <div class="data-cell">
+            <div class="metric-val">&lt;4h</div>
+            <div class="metric-lbl">avg PRD-to-PR</div>
+        </div>
     </section>
     <div class="divider"></div>
 


### PR DESCRIPTION
Closes #414

## Summary

The UI update in commit `5c02dd8` (landing page copy refresh) removed the `avg PRD-to-PR` metric from the evidence strip on the landing page. This caused `RunHistoryTests.EvidenceStrip_ContainsPipelineLabels` to fail CI.

## Change

Added a fifth `data-cell` in the evidence strip with label `avg PRD-to-PR` (static value `<4h`), restoring the metric alongside `fastest PRD-to-ship`.

**File changed:** `PRDtoProd/Pages/Index.cshtml`

## Test Results

```
Test Run Successful.
Total tests: 165
     Passed: 165
 Total time: 8.17 Seconds
```

All 165 tests pass including the previously failing `EvidenceStrip_ContainsPipelineLabels`.

## PRD Fidelity

This is a CI repair for a regression introduced by a UI commit. No PRD drift — the `avg PRD-to-PR` metric was part of the existing evidence strip contract verified by tests.

---

_This PR was created by Pipeline Assistant._




> Generated by [Pipeline Repo Assist](https://github.com/samuelkahessay/prd-to-prod/actions/runs/22807371374) · [◷](https://github.com/search?q=repo%3Asamuelkahessay%2Fprd-to-prod+%22gh-aw-workflow-id%3A+repo-assist%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Pipeline Repo Assist, engine: copilot, model: gpt-5, id: 22807371374, workflow_id: repo-assist, run: https://github.com/samuelkahessay/prd-to-prod/actions/runs/22807371374 -->

<!-- gh-aw-workflow-id: repo-assist -->