### PR TITLE
feat: shift pricing from consulting to compute + margin

### DIFF
--- a/studio/components/landing/bottom-cta.tsx
+++ b/studio/components/landing/bottom-cta.tsx
@@ -8,7 +8,7 @@ export function BottomCta() {
       <h2 className={styles.heading}>Ready to ship something?</h2>
       <p className={styles.body}>
         Send us a PRD, a rough brief, or even just an idea. We'll reply with
-        scope, timeline, and price. First project free.
+        scope, timeline, and price. Or fork the repo and run it yourself.
       </p>
       <a href={MAILTO} className={styles.ctaPrimary}>Send your PRD →</a>
       <a

--- a/studio/components/landing/hero.tsx
+++ b/studio/components/landing/hero.tsx
@@ -13,7 +13,7 @@ export function Hero() {
       <p className={styles.subtitle}>
         Autonomous agents build, review, and deploy your app from your PRD.
         You get a live URL, a real repo with CI/CD, and code you own.
-        First project free.
+        Open source. First run free.
       </p>
       <div className={styles.actions}>
         <a href={MAILTO} className={styles.ctaPrimary}>Send your PRD →</a>

--- a/studio/components/landing/pricing.tsx
+++ b/studio/components/landing/pricing.tsx
@@ -8,26 +8,26 @@ export function Pricing() {
       <span className={styles.label}>Pricing</span>
       <h2 className={styles.heading}>Pricing</h2>
       <p className={styles.subtitle}>
-        Your first project is free — so you can see exactly what the pipeline
-        delivers before paying for anything.
+        The pipeline is open source. You're paying for compute, hosting,
+        and the operational expertise to keep it running.
       </p>
 
       <div className={styles.cards}>
-        {/* Card A — Offer A (primary) */}
+        {/* Card A — Managed runs (primary) */}
         <div className={`${styles.card} ${styles.cardPrimary}`}>
           <div className={styles.badge}>Most popular</div>
-          <p className={styles.cardLabel}>Send a PRD</p>
+          <p className={styles.cardLabel}>We run it for you</p>
           <div className={styles.price}>
-            $500<span className={styles.priceUnit}>–$2K</span>
+            $99<span className={styles.priceUnit}>–$499</span>
           </div>
-          <p className={styles.pricePer}>per project</p>
+          <p className={styles.pricePer}>per pipeline run</p>
 
           <ul className={styles.features}>
-            <li>✓ Deployed app on Vercel with live URL</li>
-            <li>✓ Real GitHub repo you own</li>
-            <li>✓ CI/CD pipeline included</li>
-            <li>✓ Production-grade code — reviewed, tested, merged</li>
-            <li>✓ Self-healing CI — failures get fixed automatically</li>
+            <li>✓ Send a PRD, get a deployed app</li>
+            <li>✓ All LLM compute included</li>
+            <li>✓ Deployed on Vercel with CI/CD</li>
+            <li>✓ Real repo you own — code, history, everything</li>
+            <li>✓ Self-healing CI included</li>
             <li className={styles.featureMuted}>~ 24–48 hour turnaround</li>
           </ul>
 
@@ -35,57 +35,63 @@ export function Pricing() {
             <p className={styles.tiersTitle}>Complexity tiers</p>
             <div className={styles.tier}>
               <span>Simple app / internal tool</span>
-              <span className={styles.tierPrice}>$500</span>
+              <span className={styles.tierPrice}>$99</span>
             </div>
             <div className={styles.tier}>
               <span>Multi-feature with integrations</span>
-              <span className={styles.tierPrice}>$1K–$1.5K</span>
+              <span className={styles.tierPrice}>$249</span>
             </div>
             <div className={styles.tier}>
               <span>Complex (auth, multiple APIs)</span>
-              <span className={styles.tierPrice}>$2K</span>
+              <span className={styles.tierPrice}>$499</span>
             </div>
           </div>
 
           <a href={MAILTO} className={styles.ctaPrimary}>Send your PRD →</a>
-          <p className={styles.subCta}>First project free — no card required</p>
+          <p className={styles.subCta}>First run free — no card required</p>
         </div>
 
-        {/* Card B — Offer B (secondary) */}
+        {/* Card B — Self-hosted (secondary) */}
         <div id="for-teams" className={styles.card}>
-          <p className={styles.cardLabel}>For engineering teams</p>
+          <p className={styles.cardLabel}>Run it yourself</p>
           <div className={styles.price}>
-            $2K<span className={styles.priceUnit}>–$5K</span>
+            $0
           </div>
-          <p className={styles.pricePer}>one-time setup</p>
+          <p className={styles.pricePer}>MIT licensed, forever</p>
 
           <ul className={styles.features}>
-            <li>✓ Autonomous pipeline on your repo</li>
-            <li>✓ Issues → agents → PRs → review → merge</li>
-            <li>✓ CI failure detection + self-healing loop</li>
-            <li>✓ Policy gates for human approval boundaries</li>
-            <li>✓ LLM-agnostic (Copilot, Claude, Codex, Gemini)</li>
-            <li className={styles.featureMuted}>~ 1 week setup</li>
+            <li>✓ Full pipeline source code</li>
+            <li>✓ Bring your own LLM (Copilot, Claude, Codex, Gemini)</li>
+            <li>✓ Deploy anywhere — your infra, your rules</li>
+            <li>✓ Self-healing, review agents, auto-dispatch</li>
+            <li>✓ Same code that runs our managed service</li>
           </ul>
 
           <div className={styles.tiers}>
-            <p className={styles.tiersTitle}>Setup tiers</p>
+            <p className={styles.tiersTitle}>You'll need</p>
             <div className={styles.tier}>
-              <span>Basic pipeline (build + review + merge)</span>
-              <span className={styles.tierPrice}>$2K</span>
+              <span>GitHub repo + Actions</span>
+              <span className={styles.tierPrice}>free</span>
             </div>
             <div className={styles.tier}>
-              <span>Full pipeline (+ CI self-healing)</span>
-              <span className={styles.tierPrice}>$3.5K</span>
+              <span>LLM access (Copilot, Claude, etc.)</span>
+              <span className={styles.tierPrice}>~$19/mo</span>
             </div>
             <div className={styles.tier}>
-              <span>Full + meeting-to-main integration</span>
-              <span className={styles.tierPrice}>$5K</span>
+              <span>Hosting (Vercel, Fly, etc.)</span>
+              <span className={styles.tierPrice}>~$0–20/mo</span>
             </div>
           </div>
 
-          <a href={MAILTO} className={styles.ctaOutline}>Get in touch →</a>
-          <p className={styles.subCta}>Optional ongoing support from $200/mo</p>
+          <a
+            href="https://github.com/samuelkahessay/prd-to-prod"
+            className={styles.ctaOutline}
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub →
+          </a>
+          <p className={styles.subCta}>Optional support from $299/mo</p>
         </div>
       </div>
 

--- a/studio/test/components.test.tsx
+++ b/studio/test/components.test.tsx
@@ -58,10 +58,14 @@ describe("Pricing", () => {
     render(<Pricing />);
     expect(screen.getByRole("heading", { name: "Pricing" })).toBeInTheDocument();
     expect(screen.getByText("Most popular")).toBeInTheDocument();
-    expect(screen.getByText("Send a PRD")).toBeInTheDocument();
-    expect(screen.getByText("For engineering teams")).toBeInTheDocument();
+    expect(screen.getByText("We run it for you")).toBeInTheDocument();
+    expect(screen.getByText("Run it yourself")).toBeInTheDocument();
     expect(screen.getByText("What's in scope today")).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /Send your PRD →|Get in touch →/ })).toHaveLength(2);
+    expect(screen.getByRole("link", { name: "Send your PRD →" })).toHaveAttribute("href", MAILTO);
+    expect(screen.getByRole("link", { name: "View on GitHub →" })).toHaveAttribute(
+      "href",
+      "https://github.com/samuelkahessay/prd-to-prod",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Reframes pricing from services consulting ($500-$2K/project, $2K-$5K setup) to usage-based compute pricing ($99-$499 per pipeline run)
- Adds "Run it yourself" card: $0, MIT licensed, with transparent cost breakdown (LLM ~$19/mo, hosting ~$0-20/mo) and optional support at $299/mo
- Updates hero ("Open source. First run free."), bottom CTA ("Or fork the repo and run it yourself"), and all tests

## Why
Both gh-aw and prd-to-prod are MIT licensed. Anyone technical enough to evaluate an autonomous pipeline can fork the repo. The old consulting-style pricing pretended the code was the product. The new pricing sells compute + convenience + operational expertise — the Vercel model.

## Test plan
- [x] `npm run build` passes
- [x] All 10 component tests pass
- [ ] Vercel preview renders pricing section correctly
- [ ] Both CTA links work (mailto and GitHub)
- [ ] Cards are responsive on mobile (stack to single column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)