### PR TITLE
Fix build chat provider selection for OpenRouter

### DIFF
--- a/console/lib/llm.js
+++ b/console/lib/llm.js
@@ -1,4 +1,5 @@
-const DEFAULT_URL = "https://api.openai.com/v1/chat/completions";
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const DEFAULT_MODEL = "gpt-4.1-mini";
 const MAX_TOKENS = 2048;
 
@@ -97,9 +98,7 @@ const RESPONSE_FORMAT = {
 };
 
 function createLLMClient() {
-  const apiKey = process.env.LLM_API_KEY || process.env.OPENAI_API_KEY || process.env.OPENROUTER_API_KEY;
-  const model = process.env.LLM_MODEL || DEFAULT_MODEL;
-  const apiUrl = process.env.LLM_API_URL || DEFAULT_URL;
+  const { apiKey, apiUrl, model } = resolveProviderConfig(process.env);
 
   function buildRequestBody(messages, stream) {
     const body = {
@@ -197,6 +196,22 @@ function createLLMClient() {
   }
 
   return { streamChat, chat, parseResponse };
+}
+
+function resolveProviderConfig(env) {
+  const explicitApiUrl = env.LLM_API_URL || "";
+  const useOpenRouter =
+    explicitApiUrl.includes("openrouter.ai") ||
+    (!explicitApiUrl && !env.LLM_API_KEY && Boolean(env.OPENROUTER_API_KEY));
+
+  const apiUrl = explicitApiUrl || (useOpenRouter ? OPENROUTER_URL : OPENAI_URL);
+  const apiKey = env.LLM_API_KEY ||
+    (useOpenRouter
+      ? env.OPENROUTER_API_KEY || env.OPENAI_API_KEY
+      : env.OPENAI_API_KEY || env.OPENROUTER_API_KEY);
+  const model = env.LLM_MODEL || DEFAULT_MODEL;
+
+  return { apiKey, apiUrl, model };
 }
 
 function consumeSSEBuffer(buffer, onPayload) {

--- a/console/test/llm.test.js
+++ b/console/test/llm.test.js
@@ -2,6 +2,7 @@ const { createLLMClient } = require("../lib/llm");
 
 describe("createLLMClient", () => {
   const originalFetch = global.fetch;
+  const originalLlmApiKey = process.env.LLM_API_KEY;
   const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
   const originalApiKey = process.env.OPENROUTER_API_KEY;
   const originalModel = process.env.LLM_MODEL;
@@ -9,6 +10,11 @@ describe("createLLMClient", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    if (originalLlmApiKey === undefined) {
+      delete process.env.LLM_API_KEY;
+    } else {
+      process.env.LLM_API_KEY = originalLlmApiKey;
+    }
     if (originalOpenAiApiKey === undefined) {
       delete process.env.OPENAI_API_KEY;
     } else {
@@ -68,6 +74,38 @@ describe("createLLMClient", () => {
       },
     });
     expect(request.provider).toBeUndefined();
+  });
+
+  test("prefers OpenRouter when that key is configured and no explicit LLM url is set", async () => {
+    process.env.OPENAI_API_KEY = "stale-openai-key";
+    process.env.OPENROUTER_API_KEY = "test-openrouter-key";
+    delete process.env.LLM_API_KEY;
+    delete process.env.LLM_MODEL;
+    delete process.env.LLM_API_URL;
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content:
+                '{"status":"needs_input","message":"Need one more detail.","question":"Who is this for?","prd":null}',
+            },
+          },
+        ],
+      }),
+    });
+
+    const client = createLLMClient();
+    await client.chat([{ role: "user", content: "Build me a CRM" }]);
+    const [requestUrl, requestInit] = global.fetch.mock.calls[0];
+    const request = JSON.parse(requestInit.body);
+
+    expect(requestUrl).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(requestInit.headers.Authorization).toBe("Bearer test-openrouter-key");
+    expect(request.model).toBe("gpt-4.1-mini");
+    expect(request.provider).toEqual({ require_parameters: true });
   });
 
   test("adds the OpenRouter provider hint when explicitly targeting OpenRouter", async () => {

--- a/scripts/tests/test-bootstrap-test.sh
+++ b/scripts/tests/test-bootstrap-test.sh
@@ -34,13 +34,7 @@ case "$1" in
         for source in .github/workflows/*.md; do
           [ -f "$source" ] || continue
           lock="${source%.md}.lock.yml"
-          if command -v shasum >/dev/null 2>&1; then
-            checksum=$(shasum "$source" | awk '{print $1}')
-          elif command -v sha1sum >/dev/null 2>&1; then
-            checksum=$(sha1sum "$source" | awk '{print $1}')
-          else
-            checksum=$(cksum "$source" | awk '{print $1}')
-          fi
+          checksum=$(shasum "$source" | awk '{print $1}')
           {
             printf 'compiled-from:%s\n' "$source"
             printf 'checksum:%s\n' "$checksum"

--- a/scripts/tests/test-bootstrap-test.sh
+++ b/scripts/tests/test-bootstrap-test.sh
@@ -34,7 +34,13 @@ case "$1" in
         for source in .github/workflows/*.md; do
           [ -f "$source" ] || continue
           lock="${source%.md}.lock.yml"
-          checksum=$(shasum "$source" | awk '{print $1}')
+          if command -v shasum >/dev/null 2>&1; then
+            checksum=$(shasum "$source" | awk '{print $1}')
+          elif command -v sha1sum >/dev/null 2>&1; then
+            checksum=$(sha1sum "$source" | awk '{print $1}')
+          else
+            checksum=$(cksum "$source" | awk '{print $1}')
+          fi
           {
             printf 'compiled-from:%s\n' "$source"
             printf 'checksum:%s\n' "$checksum"


### PR DESCRIPTION
Closes #537

## Summary
- resolve LLM provider URL, key, and model together instead of always defaulting to the OpenAI endpoint
- prefer OpenRouter when `OPENROUTER_API_KEY` is configured and there is no explicit `LLM_API_URL` or `LLM_API_KEY` override
- add a regression test covering the mixed-key case where a stale OpenAI key would previously break build chat

## Validation
- `bash scripts/validate-implementation.sh`
- live smoke check of `console/lib/llm.js` `chat()` and `streamChat()` with the current shell env
