### PR TITLE
Preserve template source traceability

### DIFF
--- a/scripts/publish-scaffold-template.sh
+++ b/scripts/publish-scaffold-template.sh
@@ -77,17 +77,36 @@ log "Mirroring $SOURCE_DIR into $TARGET_REPO_DIR"
 find "$TARGET_REPO_DIR" -mindepth 1 -maxdepth 1 ! -name ".git" -exec rm -rf {} +
 cp -R "$SOURCE_DIR"/. "$TARGET_REPO_DIR"/
 
+git -C "$TARGET_REPO_DIR" config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
+git -C "$TARGET_REPO_DIR" config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+COMMIT_MESSAGE="chore: sync scaffold from ${SOURCE_REPOSITORY}@${SOURCE_SHA}"
+
 if [ -z "$(git -C "$TARGET_REPO_DIR" status --short)" ]; then
-  log "No template changes to publish"
-  echo "PUBLISHED_CHANGES=false"
+  if git -C "$TARGET_REPO_DIR" log -1 --pretty=%B | grep -F "${SOURCE_REPOSITORY}@${SOURCE_SHA}" >/dev/null; then
+    log "No template changes to publish"
+    echo "PUBLISHED_CHANGES=false"
+    exit 0
+  fi
+
+  log "No file changes, publishing source SHA traceability commit"
+  git -C "$TARGET_REPO_DIR" commit --quiet --allow-empty -m "$COMMIT_MESSAGE"
+  if [ "$PUSH_CHANGES" = "true" ]; then
+    PUSH_BRANCH="$TARGET_BRANCH"
+    if [ -z "$PUSH_BRANCH" ]; then
+      PUSH_BRANCH="$(git -C "$TARGET_REPO_DIR" rev-parse --abbrev-ref HEAD)"
+    fi
+    git -C "$TARGET_REPO_DIR" push --quiet origin "HEAD:${PUSH_BRANCH}"
+    log "Published generated template metadata to ${TEMPLATE_OWNER}/${TEMPLATE_REPO}@${PUSH_BRANCH}"
+  else
+    log "Created local metadata-only sync commit without pushing"
+  fi
+  echo "PUBLISHED_CHANGES=true"
+  echo "TARGET_REPO_DIR=$TARGET_REPO_DIR"
   exit 0
 fi
 
-git -C "$TARGET_REPO_DIR" config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
-git -C "$TARGET_REPO_DIR" config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
 git -C "$TARGET_REPO_DIR" add -A
 
-COMMIT_MESSAGE="chore: sync scaffold from ${SOURCE_REPOSITORY}@${SOURCE_SHA}"
 git -C "$TARGET_REPO_DIR" commit --quiet -m "$COMMIT_MESSAGE"
 
 if [ "$PUSH_CHANGES" = "true" ]; then

--- a/scripts/tests/test-publish-scaffold-template.sh
+++ b/scripts/tests/test-publish-scaffold-template.sh
@@ -81,4 +81,32 @@ if ! grep -q "PUBLISHED_CHANGES=false" "$OUTPUT"; then
 fi
 echo "Test 2 passed: unchanged scaffold is a no-op"
 
+COMMIT_COUNT_BEFORE=$(git -C "$TARGET_REPO_DIR" rev-list --count HEAD)
+TARGET_REPO_DIR="$TARGET_REPO_DIR" \
+SOURCE_REPOSITORY="samuelkahessay/prd-to-prod" \
+SOURCE_SHA="def456" \
+bash "$SCRIPT" "$SOURCE_DIR" > "$OUTPUT"
+COMMIT_COUNT_AFTER=$(git -C "$TARGET_REPO_DIR" rev-list --count HEAD)
+
+if [ "$COMMIT_COUNT_AFTER" -ne $((COMMIT_COUNT_BEFORE + 1)) ]; then
+  echo "FAIL: Test 3: changed source SHA should create a metadata-only sync commit" >&2
+  exit 1
+fi
+
+if [ -n "$(git -C "$TARGET_REPO_DIR" status --short)" ]; then
+  echo "FAIL: Test 3: target repo should be clean after metadata sync commit" >&2
+  exit 1
+fi
+
+if ! git -C "$TARGET_REPO_DIR" log -1 --pretty=%B | grep -q "samuelkahessay/prd-to-prod@def456"; then
+  echo "FAIL: Test 3: metadata sync commit is missing source SHA traceability" >&2
+  exit 1
+fi
+
+if ! grep -q "PUBLISHED_CHANGES=true" "$OUTPUT"; then
+  echo "FAIL: Test 3: metadata sync should report publish changes" >&2
+  exit 1
+fi
+echo "Test 3 passed: unchanged scaffold with new source SHA creates metadata sync commit"
+
 echo "publish-scaffold-template tests passed"


### PR DESCRIPTION
## Summary
- create a metadata-only template sync commit when scaffold files are unchanged but SOURCE_SHA changed
- keep exact same-SHA publishes as no-ops
- add test coverage for source-SHA-only template traceability

## Verification
- bash scripts/tests/test-publish-scaffold-template.sh
- bash scripts/tests/test-publish-scaffold-template-workflow.sh
- bash scripts/verify-v2-contracts.sh
- Pre-push console tests: 26 suites / 95 tests passed